### PR TITLE
Fix TinyVec::resize across inline/heap boundary

### DIFF
--- a/src/tiny_vec.rs
+++ b/src/tiny_vec.rs
@@ -405,7 +405,12 @@ impl<A: Arrayish> TinyVec<A> {
     A::Item: Clone,
   {
     match self {
-      TinyVec::Inline(a) => a.resize(new_len, new_val),
+      TinyVec::Inline(a) => if new_len > A::CAPACITY {
+        self.move_to_the_heap();
+        self.resize(new_len, new_val);
+      } else {
+        a.resize(new_len, new_val);
+      },
       TinyVec::Heap(v) => v.resize(new_len, new_val),
     }
   }

--- a/tests/tinyvec.rs
+++ b/tests/tinyvec.rs
@@ -31,3 +31,10 @@ fn TinyVec_drain() {
   assert_eq!(Vec::from_iter(tv.clone().drain(1..=1)), vec![2]);
   assert_eq!(Vec::from_iter(tv.clone().drain(1..=2)), vec![2, 3]);
 }
+
+#[test]
+fn TinyVec_resize() {
+  let mut tv: TinyVec<[i32; 10]> = Default::default();
+  tv.resize(20, 5);
+  assert_eq!(&tv[..], &[5; 20]);
+}


### PR DESCRIPTION
Previously it would attempt to resize the inline storage larger than it supports.