### PR TITLE
Add the SliceVec type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/Lokathor/tinyvec"
 # not even std!
 
 [features]
-default = ["grab_spare_slice"]
+default = []
 
 # Provide things that utilize the `alloc` crate, namely `TinyVec`.
 alloc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,17 +46,17 @@ all-features = true
 [profile.test]
 opt-level = 3
 
-#[workspace]
-#members = ["fuzz"]
+[workspace]
+members = ["fuzz"]
 
-#[dev-dependencies]
-#criterion = "0.3.0"
+[dev-dependencies]
+criterion = "0.3.0"
 
-#[[test]]
-#name = "tinyvec"
-#required-features = ["alloc"]
+[[test]]
+name = "tinyvec"
+required-features = ["alloc"]
 
-#[[bench]]
-#name = "macros"
-#harness = false
-#required-features = ["alloc"]
+[[bench]]
+name = "macros"
+harness = false
+required-features = ["alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ repository = "https://github.com/Lokathor/tinyvec"
 # not even std!
 
 [features]
-default = []
+default = ["grab_spare_slice"]
 
-# Provide things that utilize the `alloc` crate.
+# Provide things that utilize the `alloc` crate, namely `TinyVec`.
 alloc = []
 
 # (not part of Vec!) Extra methods to let you grab the slice of memory after the
-# "active" portion of an `ArrayVec`.
+# "active" portion of an `ArrayVec` or `SliceVec`.
 grab_spare_slice = []
 
 # allow use of nightly feature `slice_partition_dedup`,
@@ -30,8 +30,10 @@ nightly_slice_partition_dedup = []
 # use const generics for arrays
 nightly_const_generics = []
 
-# NOT considered part of the crate's SemVer!!!
-# This experimental feature adds `core::fmt::Write` to ArrayVec.
+# EXPERIMENTAL: Not part of SemVer. It adds `core::fmt::Write` to `ArrayVec`
+# and `SliceVec`. It works on Stable Rust, but Vec normally supports the
+# `std::io::Write` trait instead of `core::fmt::Write`, so we're keeping it as
+# an experimental impl only for now.
 experimental_write_impl = []
 
 [badges]
@@ -41,17 +43,20 @@ travis-ci = { repository = "Lokathor/tinyvec" }
 [package.metadata.docs.rs]
 all-features = true
 
-[workspace]
-members = ["fuzz"]
+[profile.test]
+opt-level = 3
 
-[dev-dependencies]
-criterion = "0.3.0"
+#[workspace]
+#members = ["fuzz"]
 
-[[test]]
-name = "tinyvec"
-required-features = ["alloc"]
+#[dev-dependencies]
+#criterion = "0.3.0"
 
-[[bench]]
-name = "macros"
-harness = false
-required-features = ["alloc"]
+#[[test]]
+#name = "tinyvec"
+#required-features = ["alloc"]
+
+#[[bench]]
+#name = "macros"
+#harness = false
+#required-features = ["alloc"]

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -287,6 +287,43 @@ impl<A: Array> ArrayVec<A> {
     self.set_len(new_len);
   }
 
+  /// Fill the vector until its capacity has been reached.
+  ///
+  /// Successively fills unused space in the spare slice of the vector with
+  /// elements from the iterator. It then returns the remaining iterator
+  /// without exhausting it. This also allows appending the head of an
+  /// infinite iterator.
+  ///
+  /// This is an alternative to `Extend::extend` method for cases where the
+  /// length of the iterator can not be checked. Since this vector can not
+  /// reallocate to increase its capacity, it is unclear what to do with
+  /// remaining elements in the iterator and the iterator itself. The
+  /// interface also provides no way to communicate this to the caller.
+  ///
+  /// ## Panics
+  /// * If the `next` method of the provided iterator panics.
+  ///
+  /// ## Example
+  ///
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut av = array_vec!([i32; 4]);
+  /// let mut to_inf = av.fill(0..);
+  /// assert_eq!(&av[..], [0, 1, 2, 3]);
+  /// assert_eq!(to_inf.next(), Some(4));
+  /// ```
+  #[inline]
+  pub fn fill<I: IntoIterator<Item = A::Item>>(
+    &mut self,
+    iter: I,
+  ) -> I::IntoIter {
+    let mut iter = iter.into_iter();
+    for element in iter.by_ref().take(self.capacity() - self.len()) {
+      self.push(element);
+    }
+    iter
+  }
+
   /// Wraps up an array and uses the given length as the initial length.
   ///
   /// If you want to simply use the full array, use `from` instead.
@@ -310,7 +347,7 @@ impl<A: Array> ArrayVec<A> {
   /// index.
   ///
   /// ## Panics
-  /// * If `index` > `len` or
+  /// * If `index` > `len`
   /// * If the capacity is exhausted
   ///
   /// ## Example
@@ -427,16 +464,14 @@ impl<A: Array> ArrayVec<A> {
   #[inline]
   pub fn remove(&mut self, index: usize) -> A::Item {
     let targets: &mut [A::Item] = &mut self.deref_mut()[index..];
-    let item = replace(&mut targets[0], A::Item::default());
+    let item = take(&mut targets[0]);
     targets.rotate_left(1);
     self.len -= 1;
     item
   }
 
-  /// Resize the vec to the new length.
-  ///
-  /// If it needs to be longer, it's filled with clones of the provided value.
-  /// If it needs to be shorter, it's truncated.
+  /// As [`resize_with`](ArrayVec::resize_with)
+  /// and it clones the value as the closure.
   ///
   /// ## Example
   ///
@@ -456,16 +491,7 @@ impl<A: Array> ArrayVec<A> {
   where
     A::Item: Clone,
   {
-    match new_len.checked_sub(self.len) {
-      None => self.truncate(new_len),
-      Some(0) => (),
-      Some(new_elements) => {
-        for _ in 1..new_elements {
-          self.push(new_val.clone());
-        }
-        self.push(new_val);
-      }
-    }
+    self.resize_with(new_len, || { new_val.clone() })
   }
 
   /// Resize the vec to the new length.
@@ -567,47 +593,10 @@ impl<A: Array> ArrayVec<A> {
       // just let some other call later on trigger a panic on accident when the
       // length is wrong. However, it's a lot easier to catch bugs when things
       // are more "fail-fast".
-      panic!("ArrayVec: set_len overflow!")
+      panic!("ArrayVec::set_len> new length {} exceeds capacity {}", new_len, A::CAPACITY)
     } else {
       self.len = new_len;
     }
-  }
-
-  /// Fill the vector until its capacity has been reached.
-  ///
-  /// Successively fills unused space in the spare slice of the vector with
-  /// elements from the iterator. It then returns the remaining iterator
-  /// without exhausting it. This also allows appending the head of an
-  /// infinite iterator.
-  ///
-  /// This is an alternative to `Extend::extend` method for cases where the
-  /// length of the iterator can not be checked. Since this vector can not
-  /// reallocate to increase its capacity, it is unclear what to do with
-  /// remaining elements in the iterator and the iterator itself. The
-  /// interface also provides no way to communicate this to the caller.
-  ///
-  /// ## Panics
-  /// * If the `next` method of the provided iterator panics.
-  ///
-  /// ## Example
-  ///
-  /// ```rust
-  /// # use tinyvec::*;
-  /// let mut av = array_vec!([i32; 4]);
-  /// let mut to_inf = av.fill(0..);
-  /// assert_eq!(&av[..], [0, 1, 2, 3]);
-  /// assert_eq!(to_inf.next(), Some(4));
-  /// ```
-  #[inline]
-  pub fn fill<I: IntoIterator<Item = A::Item>>(
-    &mut self,
-    iter: I,
-  ) -> I::IntoIter {
-    let mut iter = iter.into_iter();
-    for element in iter.by_ref().take(self.capacity() - self.len()) {
-      self.push(element);
-    }
-    iter
   }
 
   /// Splits the collection at the point given.

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -330,16 +330,19 @@ impl<A: Array> ArrayVec<A> {
   ///
   /// ## Panics
   ///
-  /// * The length specified must be less than or equal to the capacity of the array.
+  /// * The length specified must be less than or equal to the capacity of the
+  ///   array.
   #[inline]
   #[must_use]
   #[allow(clippy::match_wild_err_arm)]
   pub fn from_array_len(data: A, len: usize) -> Self {
     match Self::try_from_array_len(data, len) {
       Ok(out) => out,
-      Err(_) => {
-        panic!("ArrayVec::from_array_len> length {} exceeds capacity {}!", len, A::CAPACITY)
-      }
+      Err(_) => panic!(
+        "ArrayVec::from_array_len> length {} exceeds capacity {}!",
+        len,
+        A::CAPACITY
+      ),
     }
   }
 
@@ -491,7 +494,7 @@ impl<A: Array> ArrayVec<A> {
   where
     A::Item: Clone,
   {
-    self.resize_with(new_len, || { new_val.clone() })
+    self.resize_with(new_len, || new_val.clone())
   }
 
   /// Resize the vec to the new length.
@@ -510,7 +513,10 @@ impl<A: Array> ArrayVec<A> {
   ///
   /// let mut av = array_vec!([i32; 10]);
   /// let mut p = 1;
-  /// av.resize_with(4, || { p *= 2; p });
+  /// av.resize_with(4, || {
+  ///   p *= 2;
+  ///   p
+  /// });
   /// assert_eq!(&av[..], [2, 4, 8, 16]);
   /// ```
   #[inline]
@@ -593,7 +599,11 @@ impl<A: Array> ArrayVec<A> {
       // just let some other call later on trigger a panic on accident when the
       // length is wrong. However, it's a lot easier to catch bugs when things
       // are more "fail-fast".
-      panic!("ArrayVec::set_len> new length {} exceeds capacity {}", new_len, A::CAPACITY)
+      panic!(
+        "ArrayVec::set_len> new length {} exceeds capacity {}",
+        new_len,
+        A::CAPACITY
+      )
     } else {
       self.len = new_len;
     }
@@ -775,7 +785,7 @@ impl<A: Array> ArrayVec<A> {
   }
 }
 
-/// Draining iterator for `ArrayVecDrain`
+/// Draining iterator for [`ArrayVec`]
 ///
 /// See [`ArrayVec::drain`](ArrayVec::drain)
 pub struct ArrayVecDrain<'p, A: Array> {
@@ -797,15 +807,17 @@ impl<'p, A: Array> Iterator for ArrayVecDrain<'p, A> {
     }
   }
 }
-impl<'p, A: Array> FusedIterator for ArrayVecDrain<'p, A> { }
+impl<'p, A: Array> FusedIterator for ArrayVecDrain<'p, A> {}
 impl<'p, A: Array> Drop for ArrayVecDrain<'p, A> {
   #[inline]
   fn drop(&mut self) {
-    // Changed because it was moving `self`, it's also more clear and the std does the same
+    // Changed because it was moving `self`, it's also more clear and the std
+    // does the same
     self.for_each(drop);
     // Implementation very similar to [`ArrayVec::remove`](ArrayVec::remove)
     let count = self.target_end - self.target_start;
-    let targets: &mut [A::Item] = &mut self.parent.deref_mut()[self.target_start..];
+    let targets: &mut [A::Item] =
+      &mut self.parent.deref_mut()[self.target_start..];
     targets.rotate_left(count);
     self.parent.len -= count;
   }
@@ -891,7 +903,7 @@ impl<A: Array> ArrayVecIterator<A> {
     &self.data.as_slice()[self.base..self.len]
   }
 }
-impl<A: Array> FusedIterator for ArrayVecIterator<A> { }
+impl<A: Array> FusedIterator for ArrayVecIterator<A> {}
 impl<A: Array> Iterator for ArrayVecIterator<A> {
   type Item = A::Item;
   #[inline]
@@ -931,7 +943,10 @@ impl<A: Array> Iterator for ArrayVecIterator<A> {
   }
 }
 
-impl<A: Array> Debug for ArrayVecIterator<A> where A::Item: Debug {
+impl<A: Array> Debug for ArrayVecIterator<A>
+where
+  A::Item: Debug,
+{
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.debug_tuple("ArrayVecIterator").field(&self.as_slice()).finish()
@@ -1014,8 +1029,7 @@ where
 }
 
 #[cfg(feature = "experimental_write_impl")]
-impl<A: Array<Item=u8>> core::fmt::Write for ArrayVec<A>
-{
+impl<A: Array<Item = u8>> core::fmt::Write for ArrayVec<A> {
   fn write_str(&mut self, s: &str) -> core::fmt::Result {
     let my_len = self.len();
     let str_len = s.as_bytes().len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,10 @@
 //!   capacity. If you try to grow the length past the array's capacity it will
 //!   error or panic (depending on the method used).
 //! * [`SliceVec`](SliceVec) is similar, but instead of the vec having an owned
-//!   array, it holds onto a unique borrow of a slice.
+//!   array, it holds onto a unique borrow of a slice. This means that it's far
+//!   cheaper to pass around (since you don't move the whole array), but it can
+//!   be trickier to thread a lifetime marker everywhere through all your
+//!   function signatures.
 //! * (`alloc` feature) [`TinyVec`](TinyVec) is an enum that's either an
 //!   "Inline" `ArrayVec` or a "Heap" `Vec`. If it's Inline and you try to grow
 //!   the `ArrayVec` beyond its array capacity it will quietly transition into
@@ -51,8 +54,8 @@
 //!      if so they also require a Nightly compiler.
 //!    * Some methods are provided that _are not_ part of the `Vec` type, such
 //!      as additional constructor methods. In this case, the names are rather
-//!      long and whimsical in the hopes that they don't clash with any
-//!      possible future methods of `Vec`.
+//!      long and whimsical in the hopes that they don't clash with any possible
+//!      future methods of `Vec`.
 //!    * If, in the future, `Vec` stabilizes a method that clashes with an
 //!      existing extra method here then we'll simply be forced to release a
 //!      2.y.z version. Not the end of the world.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@
 //! * [`ArrayVec`](ArrayVec) is an array-backed vec-like structure with a fixed
 //!   capacity. If you try to grow the length past the array's capacity it will
 //!   error or panic (depending on the method used).
+//! * [`SliceVec`](SliceVec) is similar, but instead of the vec having an owned
+//!   array, it holds onto a unique borrow of a slice.
 //! * (`alloc` feature) [`TinyVec`](TinyVec) is an enum that's either an
 //!   "Inline" `ArrayVec` or a "Heap" `Vec`. If it's Inline and you try to grow
 //!   the `ArrayVec` beyond its array capacity it will quietly transition into
@@ -42,7 +44,7 @@
 //!      `serde` compatibility).
 //! 3) The intended API is that, _as much as possible_, these types are
 //!    essentially a "drop-in" replacement for the standard [`Vec`](Vec::<T>)
-//!    type.
+//!    type. Because of the "no `unsafe`" rule this can't be done perfectly.
 //!    * Stable `Vec` methods that the vecs here also have should be the same
 //!      general signature.
 //!    * Unstable `Vec` methods are sometimes provided via a crate feature, but
@@ -55,9 +57,11 @@
 //!      existing extra method here then we'll simply be forced to release a
 //!      2.y.z version. Not the end of the world.
 //!    * Some methods of `Vec` are simply inappropriate and will not be
-//!      implemented here. For example, `ArrayVec` cannot possibly implement
-//!      [`from_raw_parts`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.from_raw_parts).
+//!      implemented here. For example, this crate cannot possibly implement
+//!      [`from_raw_parts`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.from_raw_parts)
+//!      because it cannot call `unsafe` methods.
 
+#[allow(unused_imports)]
 use core::{
   borrow::{Borrow, BorrowMut},
   cmp::PartialEq,
@@ -83,6 +87,9 @@ pub use array::*;
 
 mod arrayvec;
 pub use arrayvec::*;
+
+mod slicevec;
+pub use slicevec::*;
 
 #[cfg(feature = "alloc")]
 mod tinyvec;

--- a/src/slicevec.rs
+++ b/src/slicevec.rs
@@ -1,0 +1,893 @@
+
+#![allow(unused_variables)]
+#![allow(missing_docs)]
+
+use super::*;
+
+/// A slice-backed vector-like data structure.
+///
+/// This is a very similar concept to `SliceVec`, but instead
+/// of the backing memory being an owned array, the backing
+/// memory is a unique-borrowed slice. You can thus create
+/// one of these structures "around" some slice that you're
+/// working with to make it easier to manipulate.
+///
+/// * Has a fixed capacity (the initial slice size).
+/// * Has a variable length.
+pub struct SliceVec<'s, T> {
+  data: &'s mut [T],
+  len: usize,
+}
+
+impl<'s, T> Default for SliceVec<'s, T> {
+  fn default() -> Self {
+    Self { data: &mut [], len: 0 }
+  }
+}
+
+impl<'s, T> Deref for SliceVec<'s, T> {
+  type Target = [T];
+  #[inline(always)]
+  #[must_use]
+  fn deref(&self) -> &Self::Target {
+    &self.data[..self.len]
+  }
+}
+
+impl<'s, T> DerefMut for SliceVec<'s, T> {
+  #[inline(always)]
+  #[must_use]
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.data[..self.len]
+  }
+}
+
+impl<'s, T, I> Index<I> for SliceVec<'s, T> where I: SliceIndex<[T]> {
+  type Output = <I as SliceIndex<[T]>>::Output;
+  #[inline(always)]
+  #[must_use]
+  fn index(&self, index: I) -> &Self::Output {
+    &self.deref()[index]
+  }
+}
+
+impl<'s, T, I> IndexMut<I> for SliceVec<'s, T> where I: SliceIndex<[T]> {
+  #[inline(always)]
+  #[must_use]
+  fn index_mut(&mut self, index: I) -> &mut Self::Output {
+    &mut self.deref_mut()[index]
+  }
+}
+
+impl<'s, T> SliceVec<'s, T> {
+  #[inline]
+  pub fn append(&mut self, other: &mut Self) {
+    todo!()
+  }
+
+  /// A `*mut` pointer to the backing slice.
+  ///
+  /// ## Safety
+  ///
+  /// This pointer has provenance over the _entire_ backing slice.
+  #[inline(always)]
+  #[must_use]
+  pub fn as_mut_ptr(&mut self) -> *mut T {
+    self.data.as_mut_ptr()
+  }
+
+  /// Performs a `deref_mut`, into unique slice form.
+  #[inline(always)]
+  #[must_use]
+  pub fn as_mut_slice(&mut self) -> &mut [T] {
+    self.deref_mut()
+  }
+
+  /// A `*const` pointer to the backing slice.
+  ///
+  /// ## Safety
+  ///
+  /// This pointer has provenance over the _entire_ backing slice.
+  #[inline(always)]
+  #[must_use]
+  pub fn as_ptr(&self) -> *const T {
+    self.data.as_ptr()
+  }
+
+  /// Performs a `deref`, into shared slice form.
+  #[inline(always)]
+  #[must_use]
+  pub fn as_slice(&self) -> &[T] {
+    self.deref()
+  }
+
+  /// The capacity of the `SliceVec`.
+  ///
+  /// This the length of the initial backing slice.
+  #[inline(always)]
+  #[must_use]
+  pub fn capacity(&self) -> usize {
+    self.data.len()
+  }
+
+  /// Truncates the `SliceVec` down to length 0.
+  #[inline(always)]
+  pub fn clear(&mut self) {
+    todo!()
+  }
+  
+  // TODO: drain
+  
+  #[inline]
+  pub fn extend_from_slice(&mut self, sli: &[T])
+  where
+    T: Clone,
+  {
+    if sli.is_empty() {
+      return;
+    }
+
+    let new_len = self.len + sli.len();
+    if new_len > self.capacity() {
+      panic!(
+        "SliceVec::extend_from_slice> total length {} exceeds capacity {}",
+        new_len,
+        self.capacity()
+      )
+    }
+
+    let target = &mut self.data[self.len..new_len];
+    target.clone_from_slice(sli);
+    self.set_len(new_len);
+  }
+
+  /// Fill the vector until its capacity has been reached.
+  ///
+  /// Successively fills unused space in the spare slice of the vector with
+  /// elements from the iterator. It then returns the remaining iterator
+  /// without exhausting it. This also allows appending the head of an
+  /// infinite iterator.
+  ///
+  /// This is an alternative to `Extend::extend` method for cases where the
+  /// length of the iterator can not be checked. Since this vector can not
+  /// reallocate to increase its capacity, it is unclear what to do with
+  /// remaining elements in the iterator and the iterator itself. The
+  /// interface also provides no way to communicate this to the caller.
+  ///
+  /// ## Panics
+  /// * If the `next` method of the provided iterator panics.
+  ///
+  /// ## Example
+  ///
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut arr = [7, 7, 7, 7];
+  /// let mut sv = SliceVec::from_slice_len(&mut arr, 0);
+  /// let mut to_inf = sv.fill(0..);
+  /// assert_eq!(&sv[..], [0, 1, 2, 3]);
+  /// assert_eq!(to_inf.next(), Some(4));
+  /// ```
+  #[inline]
+  pub fn fill<I: IntoIterator<Item = T>>(
+    &mut self,
+    iter: I,
+  ) -> I::IntoIter {
+    let mut iter = iter.into_iter();
+    for element in iter.by_ref().take(self.capacity() - self.len()) {
+      self.push(element);
+    }
+    iter
+  }
+  
+  /// Wraps up a slice and uses the given length as the initial length.
+  ///
+  /// If you want to simply use the full slice, use `from` instead.
+  ///
+  /// ## Panics
+  ///
+  /// * The length specified must be less than or equal to the capacity of the slice.
+  #[inline]
+  #[must_use]
+  #[allow(clippy::match_wild_err_arm)]
+  pub fn from_slice_len(data: &'s mut [T], len: usize) -> Self {
+    assert!(len <= data.len());
+    Self { data, len }
+  }
+
+  /// Inserts an item at the position given, moving all following elements +1
+  /// index.
+  ///
+  /// ## Panics
+  /// * If `index` > `len`
+  /// * If the capacity is exhausted
+  ///
+  /// ## Example
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut arr = [1, 2, 3, 0, 0];
+  /// let mut sv = SliceVec::from_slice_len(&mut arr, 3);
+  /// sv.insert(1, 4);
+  /// assert_eq!(sv.as_slice(), &[1, 4, 2, 3]);
+  /// sv.insert(4, 5);
+  /// assert_eq!(sv.as_slice(), &[1, 4, 2, 3, 5]);
+  /// ```
+  #[inline]
+  pub fn insert(&mut self, index: usize, item: T) {
+    if index > self.len {
+      panic!("SliceVec::insert> index {} is out of bounds {}", index, self.len);
+    }
+
+    // Try to push the element.
+    self.push(item);
+    // And move it into its place.
+    self.as_mut_slice()[index..].rotate_right(1);
+  }
+
+  /// Checks if the length is 0.
+  #[inline(always)]
+  #[must_use]
+  pub fn is_empty(&self) -> bool {
+    self.len == 0
+  }
+
+  /// The length of the `SliceVec` (in elements).
+  #[inline(always)]
+  #[must_use]
+  pub fn len(&self) -> usize {
+    self.len
+  }
+
+  /// Remove and return the last element of the vec, if there is one.
+  ///
+  /// ## Failure
+  /// * If the vec is empty you get `None`.
+  ///
+  /// ## Example
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut arr = [1, 2];
+  /// let mut sv = SliceVec::from(&mut arr);
+  /// assert_eq!(sv.pop(), Some(2));
+  /// assert_eq!(sv.pop(), Some(1));
+  /// assert_eq!(sv.pop(), None);
+  /// ```
+  #[inline]
+  pub fn pop(&mut self) -> Option<T> where T: Default {
+    if self.len > 0 {
+      self.len -= 1;
+      let out = take(&mut self.data[self.len]);
+      Some(out)
+    } else {
+      None
+    }
+  }
+
+  /// Place an element onto the end of the vec.
+  ///
+  /// ## Panics
+  /// * If the length of the vec would overflow the capacity.
+  ///
+  /// ## Example
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut arr = [0, 0];
+  /// let mut sv = SliceVec::from_slice_len(&mut arr, 0);
+  /// assert_eq!(&sv[..], []);
+  /// sv.push(1);
+  /// assert_eq!(&sv[..], [1]);
+  /// sv.push(2);
+  /// assert_eq!(&sv[..], [1, 2]);
+  /// // sv.push(3); this would overflow the ArrayVec and panic!
+  /// ```
+  #[inline(always)]
+  pub fn push(&mut self, val: T) {
+    if self.len < self.capacity() {
+      replace(&mut self.data[self.len], val);
+      self.len += 1;
+    } else {
+      panic!("SliceVec::push> capacity overflow")
+    }
+  }
+  
+  /// Removes the item at `index`, shifting all others down by one index.
+  ///
+  /// Returns the removed element.
+  ///
+  /// ## Panics
+  ///
+  /// * If the index is out of bounds.
+  ///
+  /// ## Example
+  ///
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut arr = [1, 2, 3];
+  /// let mut sv = SliceVec::from(&mut arr);
+  /// assert_eq!(sv.remove(1), 2);
+  /// assert_eq!(&sv[..], [1, 3]);
+  /// ```
+  #[inline]
+  pub fn remove(&mut self, index: usize) -> T where T: Default {
+    let targets: &mut [T] = &mut self.deref_mut()[index..];
+    let item = take(&mut targets[0]);
+    targets.rotate_left(1);
+    self.len -= 1;
+    item
+  }
+
+  /// As [`resize_with`](SliceVec::resize_with)
+  /// and it clones the value as the closure.
+  ///
+  /// ## Example
+  ///
+  /// ```rust
+  /// # use tinyvec::*;
+  /// // bigger
+  /// let mut arr = ["hello", "", "", "", ""];
+  /// let mut sv = SliceVec::from_slice_len(&mut arr, 1);
+  /// sv.resize(3, "world");
+  /// assert_eq!(&sv[..], ["hello", "world", "world"]);
+  ///
+  /// // smaller
+  /// let mut arr = ['a', 'b', 'c', 'd'];
+  /// let mut sv = SliceVec::from(&mut arr);
+  /// sv.resize(2, 'z');
+  /// assert_eq!(&sv[..], ['a', 'b']);
+  /// ```
+  #[inline]
+  pub fn resize(&mut self, new_len: usize, new_val: T)
+  where
+    T: Clone,
+  {
+    self.resize_with(new_len, || { new_val.clone() })
+  }
+
+  /// Resize the vec to the new length.
+  ///
+  /// * If it needs to be longer, it's filled with repeated calls to the provided
+  ///   function.
+  /// * If it needs to be shorter, it's truncated.
+  ///   * If the type needs to drop the truncated slots are filled with calls
+  ///     to the provided function.
+  ///
+  /// ## Example
+  ///
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut arr = [1, 2, 3, 7, 7, 7, 7];
+  /// let mut sv = SliceVec::from_slice_len(&mut arr, 3);
+  /// sv.resize_with(5, Default::default);
+  /// assert_eq!(&sv[..], [1, 2, 3, 0, 0]);
+  ///
+  /// let mut arr = [0, 0, 0, 0];
+  /// let mut sv = SliceVec::from_slice_len(&mut arr, 0);
+  /// let mut p = 1;
+  /// sv.resize_with(4, || { p *= 2; p });
+  /// assert_eq!(&sv[..], [2, 4, 8, 16]);
+  /// ```
+  #[inline]
+  pub fn resize_with<F: FnMut() -> T>(
+    &mut self,
+    new_len: usize,
+    mut f: F,
+  ) {
+    match new_len.checked_sub(self.len) {
+      None => if needs_drop::<T>() {
+        while self.len() > new_len {
+          self.len -= 1;
+          replace(&mut self.data[self.len], f());
+        }
+      } else {
+        self.len = new_len;
+      },
+      Some(new_elements) => {
+        for _ in 0..new_elements {
+          self.push(f());
+        }
+      }
+    }
+  }
+
+  /// Walk the vec and keep only the elements that pass the predicate given.
+  ///
+  /// ## Example
+  ///
+  /// ```rust
+  /// # use tinyvec::*;
+  ///
+  /// let mut arr = [1, 1, 2, 3, 3, 4];
+  /// let mut sv = SliceVec::from(&mut arr);
+  /// sv.retain(|&x| x % 2 == 0);
+  /// assert_eq!(&sv[..], [2, 4]);
+  /// ```
+  #[inline]
+  pub fn retain<F: FnMut(&T) -> bool>(&mut self, mut acceptable: F) where T:Default {
+    // Drop guard to contain exactly the remaining elements when the test
+    // panics.
+    struct JoinOnDrop<'vec, Item> {
+      items: &'vec mut [Item],
+      done_end: usize,
+      // Start of tail relative to `done_end`.
+      tail_start: usize,
+    }
+
+    impl<Item> Drop for JoinOnDrop<'_, Item> {
+      fn drop(&mut self) {
+        self.items[self.done_end..].rotate_left(self.tail_start);
+      }
+    }
+
+    let mut rest = JoinOnDrop {
+      items: self.data,
+      done_end: 0,
+      tail_start: 0,
+    };
+
+    for idx in 0..self.len {
+      // Loop start invariant: idx = rest.done_end + rest.tail_start
+      if !acceptable(&rest.items[idx]) {
+        let _ = take(&mut rest.items[idx]);
+        self.len -= 1;
+        rest.tail_start += 1;
+      } else {
+        rest.items.swap(rest.done_end, idx);
+        rest.done_end += 1;
+      }
+    }
+  }
+
+  /// Forces the length of the vector to `new_len`.
+  ///
+  /// ## Panics
+  /// * If `new_len` is greater than the vec's capacity.
+  ///
+  /// ## Safety
+  /// * This is a fully safe operation! The inactive memory already counts as
+  ///   "initialized" by Rust's rules.
+  /// * Other than "the memory is initialized" there are no other guarantees
+  ///   regarding what you find in the inactive portion of the vec.
+  #[inline(always)]
+  pub fn set_len(&mut self, new_len: usize) {
+    if new_len > self.capacity() {
+      // Note(Lokathor): Technically we don't have to panic here, and we could
+      // just let some other call later on trigger a panic on accident when the
+      // length is wrong. However, it's a lot easier to catch bugs when things
+      // are more "fail-fast".
+      panic!("SliceVec::set_len> new length {} exceeds capaity {}", new_len, self.capacity())
+    } else {
+      self.len = new_len;
+    }
+  }
+
+  /// Splits the collection at the point given.
+  ///
+  /// * `[0, at)` stays in this vec (and this vec is now full).
+  /// * `[at, len)` ends up in the new vec (with any spare capacity).
+  ///
+  /// ## Panics
+  /// * if `at` > `self.len()`
+  ///
+  /// ## Example
+  ///
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut arr = [1, 2, 3];
+  /// let mut sv = SliceVec::from(&mut arr);
+  /// let sv2 = sv.split_off(1);
+  /// assert_eq!(&sv[..], [1]);
+  /// assert_eq!(&sv2[..], [2, 3]);
+  /// ```
+  #[inline]
+  pub fn split_off<'a>(&'a mut self, at: usize) -> SliceVec<'s, T>
+  {
+    let mut new = Self::default();
+    let backing: &'s mut [T] = replace(&mut self.data, &mut []);
+    let (me, other) = backing.split_at_mut(at);
+    new.len = self.len - at;
+    new.data = other;
+    self.len = me.len();
+    self.data = me;
+    new
+  }
+  
+  /// Remove an element, swapping the end of the vec into its place.
+  ///
+  /// ## Panics
+  /// * If the index is out of bounds.
+  ///
+  /// ## Example
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut arr = ["foo", "bar", "quack", "zap"];
+  /// let mut sv = SliceVec::from(&mut arr);
+  ///
+  /// assert_eq!(sv.swap_remove(1), "bar");
+  /// assert_eq!(&sv[..], ["foo", "zap", "quack"]);
+  ///
+  /// assert_eq!(sv.swap_remove(0), "foo");
+  /// assert_eq!(&sv[..], ["quack", "zap"]);
+  /// ```
+  #[inline]
+  pub fn swap_remove(&mut self, index: usize) -> T where T: Default {
+    assert!(
+      index < self.len,
+      "SliceVec::swap_remove> index {} is out of bounds {}",
+      index,
+      self.len
+    );
+    if index == self.len - 1 {
+      self.pop().unwrap()
+    } else {
+      let i = self.pop().unwrap();
+      replace(&mut self[index], i)
+    }
+  }
+
+  /// Reduces the vec's length to the given value.
+  ///
+  /// If the vec is already shorter than the input, nothing happens.
+  #[inline]
+  pub fn truncate(&mut self, new_len: usize) where T: Default {
+    if needs_drop::<T>() {
+      while self.len > new_len {
+        self.pop();
+      }
+    } else {
+      self.len = self.len.min(new_len);
+    }
+  }
+
+  /// Wraps a slice, using the given length as the starting length.
+  ///
+  /// If you want to use the whole length of the slice, you can just use the
+  /// `From` impl.
+  ///
+  /// ## Failure
+  ///
+  /// If the given length is greater than the length of the slice you get `None`.
+  #[inline]
+  pub fn try_from_slice_len(data: &'s mut [T], len: usize) -> Option<Self> {
+    if len <= data.len() {
+      Some(Self { data, len })
+    } else {
+      None
+    }
+  }
+}
+
+#[cfg(feature = "grab_spare_slice")]
+impl<'s, T> SliceVec<'s, T> {
+  /// Obtain the shared slice of the array _after_ the active memory.
+  ///
+  /// ## Example
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut arr = [0; 4];
+  /// let mut sv = SliceVec::from_slice_len(&mut arr, 0);
+  /// assert_eq!(sv.grab_spare_slice().len(), 4);
+  /// sv.push(10);
+  /// sv.push(11);
+  /// sv.push(12);
+  /// sv.push(13);
+  /// assert_eq!(sv.grab_spare_slice().len(), 0);
+  /// ```
+  #[inline(always)]
+  pub fn grab_spare_slice(&self) -> &[T] {
+    &self.data[self.len..]
+  }
+
+  /// Obtain the mutable slice of the array _after_ the active memory.
+  ///
+  /// ## Example
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut arr = [0; 4];
+  /// let mut sv = SliceVec::from_slice_len(&mut arr, 0);
+  /// assert_eq!(sv.grab_spare_slice_mut().len(), 4);
+  /// sv.push(10);
+  /// sv.push(11);
+  /// assert_eq!(sv.grab_spare_slice_mut().len(), 2);
+  /// ```
+  #[inline(always)]
+  pub fn grab_spare_slice_mut(&mut self) -> &mut [T] {
+    &mut self.data[self.len..]
+  }
+}
+
+impl<'s, T> From<&'s mut [T]> for SliceVec<'s, T> {
+  /// Uses the full slice as the initial length.
+  /// ## Example
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut arr = [0_i32; 2];
+  /// let mut sv = SliceVec::from(&mut arr[..]);
+  /// ```
+  fn from(data: &'s mut [T]) -> Self {
+    let len = data.len();
+    Self { data, len }
+  }
+}
+
+impl<'s, T, A> From<&'s mut A> for SliceVec<'s, T> where A: AsMut<[T]> {
+  /// Calls `AsRef::as_mut` then uses the full slice as the initial length.
+  /// ## Example
+  /// ```rust
+  /// # use tinyvec::*;
+  /// let mut arr = [0, 0];
+  /// let mut sv = SliceVec::from(&mut arr);
+  /// ```
+  fn from(a: &'s mut A) -> Self {
+    let data = a.as_mut();
+    let len = data.len();
+    Self { data, len }
+  }
+}
+
+impl<'s, T> AsMut<[T]> for SliceVec<'s, T> {
+  #[inline(always)]
+  #[must_use]
+  fn as_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+}
+
+impl<'s, T> AsRef<[T]> for SliceVec<'s, T> {
+  #[inline(always)]
+  #[must_use]
+  fn as_ref(&self) -> &[T] {
+    &*self
+  }
+}
+
+impl<'s, T> Borrow<[T]> for SliceVec<'s, T> {
+  #[inline(always)]
+  #[must_use]
+  fn borrow(&self) -> &[T] {
+    &*self
+  }
+}
+
+impl<'s, T> BorrowMut<[T]> for SliceVec<'s, T> {
+  #[inline(always)]
+  #[must_use]
+  fn borrow_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+}
+
+impl<'s, T> Extend<T> for SliceVec<'s, T> {
+  #[inline]
+  fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+    for t in iter {
+      self.push(t)
+    }
+  }
+}
+
+impl<'s, T> PartialEq for SliceVec<'s, T>
+where
+  T: PartialEq,
+{
+  #[inline]
+  #[must_use]
+  fn eq(&self, other: &Self) -> bool {
+    self.as_slice().eq(other.as_slice())
+  }
+}
+impl<'s, T> Eq for SliceVec<'s, T> where T: Eq {}
+
+impl<'s, T> PartialOrd for SliceVec<'s, T>
+where
+  T: PartialOrd,
+{
+  #[inline]
+  #[must_use]
+  fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+    self.as_slice().partial_cmp(other.as_slice())
+  }
+}
+impl<'s, T> Ord for SliceVec<'s, T>
+where
+  T: Ord,
+{
+  #[inline]
+  #[must_use]
+  fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+    self.as_slice().cmp(other.as_slice())
+  }
+}
+
+impl<'s, T> PartialEq<&[T]> for SliceVec<'s, T>
+where
+  T: PartialEq,
+{
+  #[inline]
+  #[must_use]
+  fn eq(&self, other: &&[T]) -> bool {
+    self.as_slice().eq(*other)
+  }
+}
+
+impl<'s, T> Hash for SliceVec<'s, T>
+where
+  T: Hash,
+{
+  #[inline]
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.as_slice().hash(state)
+  }
+}
+
+#[cfg(feature = "experimental_write_impl")]
+impl<'s> core::fmt::Write for SliceVec<'s, u8>
+{
+  fn write_str(&mut self, s: &str) -> core::fmt::Result {
+    let my_len = self.len();
+    let str_len = s.as_bytes().len();
+    if my_len + str_len <= self.capacity() {
+      let remainder = &mut self.data[my_len..];
+      let target = &mut remainder[..str_len];
+      target.copy_from_slice(s.as_bytes());
+      Ok(())
+    } else {
+      Err(core::fmt::Error)
+    }
+  }
+}
+
+// // // // // // // //
+// Formatting impls
+// // // // // // // //
+
+impl<'s, T> Binary for SliceVec<'s, T>
+where
+  T: Binary,
+{
+  #[allow(clippy::missing_inline_in_public_items)]
+  fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+    write!(f, "[")?;
+    for (i, elem) in self.iter().enumerate() {
+      if i > 0 {
+        write!(f, ", ")?;
+      }
+      Binary::fmt(elem, f)?;
+    }
+    write!(f, "]")
+  }
+}
+
+impl<'s, T> Debug for SliceVec<'s, T>
+where
+  T: Debug,
+{
+  #[allow(clippy::missing_inline_in_public_items)]
+  fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+    write!(f, "[")?;
+    for (i, elem) in self.iter().enumerate() {
+      if i > 0 {
+        write!(f, ", ")?;
+      }
+      Debug::fmt(elem, f)?;
+    }
+    write!(f, "]")
+  }
+}
+
+impl<'s, T> Display for SliceVec<'s, T>
+where
+  T: Display,
+{
+  #[allow(clippy::missing_inline_in_public_items)]
+  fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+    write!(f, "[")?;
+    for (i, elem) in self.iter().enumerate() {
+      if i > 0 {
+        write!(f, ", ")?;
+      }
+      Display::fmt(elem, f)?;
+    }
+    write!(f, "]")
+  }
+}
+
+impl<'s, T> LowerExp for SliceVec<'s, T>
+where
+  T: LowerExp,
+{
+  #[allow(clippy::missing_inline_in_public_items)]
+  fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+    write!(f, "[")?;
+    for (i, elem) in self.iter().enumerate() {
+      if i > 0 {
+        write!(f, ", ")?;
+      }
+      LowerExp::fmt(elem, f)?;
+    }
+    write!(f, "]")
+  }
+}
+
+impl<'s, T> LowerHex for SliceVec<'s, T>
+where
+  T: LowerHex,
+{
+  #[allow(clippy::missing_inline_in_public_items)]
+  fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+    write!(f, "[")?;
+    for (i, elem) in self.iter().enumerate() {
+      if i > 0 {
+        write!(f, ", ")?;
+      }
+      LowerHex::fmt(elem, f)?;
+    }
+    write!(f, "]")
+  }
+}
+
+impl<'s, T> Octal for SliceVec<'s, T>
+where
+  T: Octal,
+{
+  #[allow(clippy::missing_inline_in_public_items)]
+  fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+    write!(f, "[")?;
+    for (i, elem) in self.iter().enumerate() {
+      if i > 0 {
+        write!(f, ", ")?;
+      }
+      Octal::fmt(elem, f)?;
+    }
+    write!(f, "]")
+  }
+}
+
+impl<'s, T> Pointer for SliceVec<'s, T>
+where
+  T: Pointer,
+{
+  #[allow(clippy::missing_inline_in_public_items)]
+  fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+    write!(f, "[")?;
+    for (i, elem) in self.iter().enumerate() {
+      if i > 0 {
+        write!(f, ", ")?;
+      }
+      Pointer::fmt(elem, f)?;
+    }
+    write!(f, "]")
+  }
+}
+
+impl<'s, T> UpperExp for SliceVec<'s, T>
+where
+  T: UpperExp,
+{
+  #[allow(clippy::missing_inline_in_public_items)]
+  fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+    write!(f, "[")?;
+    for (i, elem) in self.iter().enumerate() {
+      if i > 0 {
+        write!(f, ", ")?;
+      }
+      UpperExp::fmt(elem, f)?;
+    }
+    write!(f, "]")
+  }
+}
+
+impl<'s, T> UpperHex for SliceVec<'s, T>
+where
+  T: UpperHex,
+{
+  #[allow(clippy::missing_inline_in_public_items)]
+  fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+    write!(f, "[")?;
+    for (i, elem) in self.iter().enumerate() {
+      if i > 0 {
+        write!(f, ", ")?;
+      }
+      UpperHex::fmt(elem, f)?;
+    }
+    write!(f, "]")
+  }
+}

--- a/src/slicevec.rs
+++ b/src/slicevec.rs
@@ -66,8 +66,13 @@ where
 
 impl<'s, T> SliceVec<'s, T> {
   #[inline]
-  pub fn append(&mut self, other: &mut Self) {
-    unimplemented!()
+  pub fn append(&mut self, other: &mut Self)
+  where
+    T: Default,
+  {
+    for item in other.drain(..) {
+      self.push(item)
+    }
   }
 
   /// A `*mut` pointer to the backing slice.

--- a/src/slicevec.rs
+++ b/src/slicevec.rs
@@ -62,7 +62,7 @@ impl<'s, T, I> IndexMut<I> for SliceVec<'s, T> where I: SliceIndex<[T]> {
 impl<'s, T> SliceVec<'s, T> {
   #[inline]
   pub fn append(&mut self, other: &mut Self) {
-    todo!()
+    unimplemented!()
   }
 
   /// A `*mut` pointer to the backing slice.
@@ -112,11 +112,17 @@ impl<'s, T> SliceVec<'s, T> {
 
   /// Truncates the `SliceVec` down to length 0.
   #[inline(always)]
-  pub fn clear(&mut self) {
-    todo!()
+  pub fn clear(&mut self) where T: Default {
+    self.truncate(0)
   }
   
-  // TODO: drain
+  #[inline]
+  pub fn drain<R: RangeBounds<usize>>(
+    &mut self,
+    range: R,
+  ) -> () {
+    unimplemented!()
+  }
   
   #[inline]
   pub fn extend_from_slice(&mut self, sli: &[T])

--- a/src/slicevec.rs
+++ b/src/slicevec.rs
@@ -527,7 +527,7 @@ impl<'s, T> SliceVec<'s, T> {
       // length is wrong. However, it's a lot easier to catch bugs when things
       // are more "fail-fast".
       panic!(
-        "SliceVec::set_len> new length {} exceeds capaity {}",
+        "SliceVec::set_len> new length {} exceeds capacity {}",
         new_len,
         self.capacity()
       )

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -709,6 +709,12 @@ impl<A: Array> From<ArrayVec<A>> for TinyVec<A> {
   }
 }
 
+impl<A: Array> From<A> for TinyVec<A> {
+  fn from(array: A) -> Self {
+    TinyVec::Inline(ArrayVec::from(array))
+  }
+}
+
 impl<T, A> From<&'_ [T]> for TinyVec<A>
 where
   T: Clone + Default,

--- a/tests/tinyvec.rs
+++ b/tests/tinyvec.rs
@@ -84,3 +84,10 @@ fn TinyVec_from_slice_impl() {
     TinyVec::Inline(ArrayVec::from_array_len(same_size, 4));
   assert_eq!(TinyVec::from(&same_size[..]), tinyvec);
 }
+
+#[test]
+fn TinyVec_from_array() {
+  let array = [9, 8, 7, 6, 5, 4, 3, 2, 1];
+  let tv = TinyVec::from(array);
+  assert_eq!(&array, &tv[..]);
+}

--- a/tests/tinyvec.rs
+++ b/tests/tinyvec.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "alloc")]
+
 #![allow(bad_style)]
 #![allow(clippy::redundant_clone)]
 


### PR DESCRIPTION
SliceVec is almost exactly like ArrayVec, but instead of an owned array it's a borrowed unique slice.

This will publish as a patch version update (0.3.4)