### PR TITLE
impl IntoIterator for &/&mut ArrayVec

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -959,6 +959,26 @@ impl<A: Array> IntoIterator for ArrayVec<A> {
   }
 }
 
+impl<'a, A: Array> IntoIterator for &'a mut ArrayVec<A> {
+  type Item = &'a mut A::Item;
+  type IntoIter = core::slice::IterMut<'a, A::Item>;
+  #[inline(always)]
+  #[must_use]
+  fn into_iter(self) -> Self::IntoIter {
+    self.iter_mut()
+  }
+}
+
+impl<'a, A: Array> IntoIterator for &'a ArrayVec<A> {
+  type Item = &'a A::Item;
+  type IntoIter = core::slice::Iter<'a, A::Item>;
+  #[inline(always)]
+  #[must_use]
+  fn into_iter(self) -> Self::IntoIter {
+    self.iter()
+  }
+}
+
 impl<A: Array> PartialEq for ArrayVec<A>
 where
   A::Item: PartialEq,

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -840,7 +840,7 @@ impl<A: Array> IntoIterator for TinyVec<A> {
 
 impl<'a, A: Array> IntoIterator for &'a mut TinyVec<A> {
   type Item = &'a mut A::Item;
-  type IntoIter = alloc::slice::IterMut<'a, A::Item>;
+  type IntoIter = core::slice::IterMut<'a, A::Item>;
   #[inline(always)]
   #[must_use]
   fn into_iter(self) -> Self::IntoIter {
@@ -850,7 +850,7 @@ impl<'a, A: Array> IntoIterator for &'a mut TinyVec<A> {
 
 impl<'a, A: Array> IntoIterator for &'a TinyVec<A> {
   type Item = &'a A::Item;
-  type IntoIter = alloc::slice::Iter<'a, A::Item>;
+  type IntoIter = core::slice::Iter<'a, A::Item>;
   #[inline(always)]
   #[must_use]
   fn into_iter(self) -> Self::IntoIter {

--- a/tests/arrayvec.rs
+++ b/tests/arrayvec.rs
@@ -99,8 +99,16 @@ fn ArrayVec_iteration() {
 
   let av = array_vec!([i32; 4], 10, 11, 12, 13);
 
-  let av2: ArrayVec<[i32; 4]> = av.clone().into_iter().collect();
+  let mut av2: ArrayVec<[i32; 4]> = av.clone().into_iter().collect();
   assert_eq!(av, av2);
+
+  // IntoIterator for &mut ArrayVec
+  for x in &mut av2 {
+    *x = -*x;
+  }
+
+  // IntoIterator for &ArrayVec
+  assert!(av.iter().zip(&av2).all(|(&a, &b)| a == -b));
 }
 
 #[test]


### PR DESCRIPTION
These just create slice iterators, but the impls are useful to have for
contexts that don't auto-deref, as in the new tests.