### PR TITLE
Modify tiny_vec! to avoid error on non-Copy types

### DIFF
--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -47,8 +47,8 @@ macro_rules! tiny_vec {
       // If we have more `$elem` than the `CAPACITY` we will simply go directly
       // to constructing on the heap.
       match $crate::TinyVec::constructor_for_capacity(INVOKED_ELEM_COUNT) {
-        TinyVecConstructor::Inline(f) => f($crate::array_vec!($array_type, $($elem),*)),
-        TinyVecConstructor::Heap(f) => f(vec!($($elem),*)),
+        $crate::TinyVecConstructor::Inline(f) => f($crate::array_vec!($array_type, $($elem),*)),
+        $crate::TinyVecConstructor::Heap(f) => f(vec!($($elem),*)),
       }
     }
   };

--- a/tests/tinyvec.rs
+++ b/tests/tinyvec.rs
@@ -93,3 +93,10 @@ fn TinyVec_from_array() {
   let tv = TinyVec::from(array);
   assert_eq!(&array, &tv[..]);
 }
+
+#[test]
+fn TinyVec_macro_non_copy() {
+  // must use a variable here to avoid macro shenanigans
+  let s = String::new();
+  let _: TinyVec<[String; 10]> = tiny_vec!([String; 10], s);
+}


### PR DESCRIPTION
Using $elem in two closures in the previous version of the macro created errors when using types that don't implement Copy. Moving the decision of whether to allocate or use an inline array to the macro invocation resolves this error as the borrow checker can see that both branches are never taken together.

Here's an example of the error I saw in my project because of this problem:
```
error[E0382]: use of moved value: `data`
  --> src\events\actions.rs:65:19
   |
58 |             Action::Single(data) => match other {
   |                            ---- move occurs because `data` has type `events::actions::ActionData`, which does not implement the `Copy` trait
...
65 |                     Action::Many(tiny_vec![[ActionData; 10], data, other_data])
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----^^^^^^^^^^^^^
   |                                  |                           |
   |                                  |                           variable moved due to use in closure
   |                                  |                           use occurs due to use in closure
   |                                  value moved into closure here
   |                                  value used here after move
   |
```