### PR TITLE
Pre-allocate memory in extend_from_slice, extend and append functions

### DIFF
--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -183,9 +183,15 @@ impl<A: Array> TinyVec<A> {
   #[inline]
   pub fn append(&mut self, other: &mut Self) {
     self.reserve(other.len());
+    let iter = other.drain(..);
 
-    for item in other.drain(..) {
-      self.push(item)
+    let arr = match self {
+      TinyVec::Heap(h) => return h.extend(iter),
+      TinyVec::Inline(ref mut a) => a,
+    };
+
+    for item in iter {
+      arr.push(item)
     }
   }
 

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -360,9 +360,7 @@ impl<A: Array> TinyVec<A> {
       return self.extend_from_slice(sli);
     }
 
-    for i in sli {
-      arr.push(i.clone())
-    }
+    arr.extend_from_slice(sli);
   }
 
   /// Wraps up an array and uses the given length as the initial length.

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -727,6 +727,10 @@ impl<A: Array> BorrowMut<[A::Item]> for TinyVec<A> {
 impl<A: Array> Extend<A::Item> for TinyVec<A> {
   #[inline]
   fn extend<T: IntoIterator<Item = A::Item>>(&mut self, iter: T) {
+    let iter = iter.into_iter();
+    let (lower_bound, _) = iter.size_hint();
+    self.reserve(lower_bound);
+
     for t in iter {
       self.push(t)
     }

--- a/tests/tinyvec.rs
+++ b/tests/tinyvec.rs
@@ -99,3 +99,4 @@ fn TinyVec_macro_non_copy() {
   let s = String::new();
   let _: TinyVec<[String; 10]> = tiny_vec!([String; 10] => s);
 }
+


### PR DESCRIPTION
Now `extend_from_slice`, `extend` and `append` pre-allocate memory, which in theory should be faster (benchmarks are still needed to proof this)