### PR TITLE
Relicense from `Zlib` to `Zlib OR Apache-2.0 OR MIT`

### DIFF
--- a/src/arrayset.rs
+++ b/src/arrayset.rs
@@ -2,7 +2,7 @@
 
 // This was contributed by user `dhardy`! Big thanks.
 
-use super::{Array, take};
+use super::{take, Array};
 use core::{
   borrow::Borrow,
   fmt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,21 +19,43 @@
 //!
 //! Similarly, there is also a [`SliceVec`] type available, which is a vec-like
 //! that's backed by a slice you provide. You can add and remove elements, but
-//! if you overflow the vec it will panic.
+//! if you overflow the slice it will panic.
 //!
 //! With the `alloc` feature enabled, the crate also has a [`TinyVec`] type.
 //! This is an enum type which is either an `Inline(ArrayVec)` or a `Heap(Vec)`.
 //! If a `TinyVec` is `Inline` and would overflow it automatically transitions
 //! itself into being `Heap` mode instead of a panic.
 //!
-//! All of this is done with no `unsafe` code within the crate. (Technically
+//! All of this is done with no `unsafe` code within the crate. Technically
 //! the `Vec` type from the standard library uses `unsafe` internally, but *this
-//! crate* introduces no new `unsafe` code into your project).
+//! crate* introduces no new `unsafe` code into your project.
 //!
-//! The limitation on all of this is that the element type of a vec from this
-//! crate must support the [`Default`] trait. This means that this crate isn't
-//! suitable for all situations, but a very surprising number of types do
-//! support `Default`.
+//! The limitation is that the element type of a vec from this crate must
+//! support the [`Default`] trait. This means that this crate isn't suitable for
+//! all situations, but a very surprising number of types do support `Default`.
+//!
+//! ## API
+//! The general goal of the crate is that, as much as possible, the vecs here
+//! should be a "drop in" replacement for the standard library `Vec` type. We
+//! strive to provide all of the `Vec` methods with the same names and
+//! signatures. The "exception" is of course that the element type of each
+//! method will have a `Default` bound that's not part of the normal `Vec` type.
+//!
+//! The vecs here also have additional methods that aren't on the `Vec` type. In
+//! this case, the names tend to be fairly long so that they are unlikely to
+//! clash with any future methods added to `Vec`.
+//!
+//! ## Stability
+//! `tinyvec` is starting to get some real usage within the ecosystem! The more
+//! popular you are, the less people want you breaking anything that they're
+//! using.
+//!
+//! * With the 0.4 release we had to make a small breaking change to how the vec
+//!   creation macros work, because of an unfortunate problem with how `rustc`
+//!   was parsing things under the old syntax.
+//!
+//! If we don't have any more unexpected problems, I'd like to declare the crate
+//! to be 1.0 by the end of 2020.
 
 #[allow(unused_imports)]
 use core::{


### PR DESCRIPTION
While it's quite clear that the Zlib license is strictly better for the user than the MIT license, it's also the case that Rust projects generally expect to have `Apache-2.0 OR MIT` as the license.

As `tinyvec` picks up in popularity, it's somehow become a dependency of the `rust-analyzer` project, and they're requesting that we add those licenses as options (https://github.com/Lokathor/tinyvec/issues/79).

This PR is to change the crate license from just `Zlib` to instead be `Zlib OR Apache-2.0 or MIT`.

The general understanding for what a re-license entails is that we need to have a sign off from all previous contributors or replace any contributions they made. In the extreme case of not being able to contact someone we could see about just replacing their contributions anyway, but I don't think that anyone has suddenly disappeared so we should be able to get a response from everyone.

Obviously as the person starting the PR, I'm agreeing to do this, but everyone else is about to get a github ping.

Please comment that you either agree or disagree with the license change. I'll check the boxes as people reply.
* [x] @Shnatsel made some contributions to the docs in the past, but they explained (on Discord) that their employer wouldn't allow a relicense without contacting the company's legal team and going through a whole thing, so I've simply replaced the crate docs from scratch, since they needed a bit of an update anyway.
* [x] @ThatsNoMoon 
* [x] @cuviper
* [x] @dhardy
* [x] @dxenonb
* [x] @rozaliev
* [x] @mental32
* [x] @mgostIH
* [x] @repnop
* [x] @HeroicKatora
* [x] @Nemo157

And while I've got your attention I'd like to again **thank everyone** who has contributed. `tinyvec` actually has the most contributors out of all the projects I've worked on and it's always been very nice getting contributions.

Closes https://github.com/Lokathor/tinyvec/issues/79