### PR TITLE
Make capacity() methods not rely on Array::CAPACITY

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -194,7 +194,7 @@ impl<A: Array> ArrayVec<A> {
   #[inline(always)]
   #[must_use]
   pub fn capacity(&self) -> usize {
-    A::CAPACITY
+    self.data.as_slice().len()
   }
 
   /// Truncates the `ArrayVec` down to length 0.

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -194,6 +194,9 @@ impl<A: Array> ArrayVec<A> {
   #[inline(always)]
   #[must_use]
   pub fn capacity(&self) -> usize {
+    // Note: This shouldn't use A::CAPACITY, because unsafe code can't rely on
+    // any Array invariants. This ensures that at the very least, the returned
+    // value is a valid length for a subslice of the backing array.
     self.data.as_slice().len()
   }
 

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -212,7 +212,7 @@ impl<A: Array> TinyVec<A> {
   #[must_use]
   pub fn capacity(&self) -> usize {
     match self {
-      TinyVec::Inline(_) => A::CAPACITY,
+      TinyVec::Inline(v) => v.capacity(),
       TinyVec::Heap(v) => v.capacity(),
     }
   }

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -212,6 +212,7 @@ impl<A: Array> TinyVec<A> {
   #[must_use]
   pub fn capacity(&self) -> usize {
     match self {
+      // Note: this shouldn't use A::CAPACITY. See ArrayVec::capacity().
       TinyVec::Inline(v) => v.capacity(),
       TinyVec::Heap(v) => v.capacity(),
     }


### PR DESCRIPTION
Because `Array` isn't an `unsafe trait`, `unsafe` code cannot depend on the length of a slice produced by `Array::as_slice` to be at least as long as `Array::CAPACITY`. This means that `unsafe` code also cannot depend on `[ArrayVec, TinyVec]::capacity()` methods that return `Array::CAPACITY`. Returning the result of a slice `len()` call ensures that if nothing else, with a sound implementation of `Array`, `capacity()` methods will return a valid length for a sub-slice of the backing array.