### PR TITLE
Add ArrayVec::splice and TinyVec::splice

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -147,9 +147,11 @@ impl<A: Array> ArrayVec<A> {
   #[inline]
   pub fn append(&mut self, other: &mut Self) {
     let new_len = self.len() + other.len();
-    assert!(new_len <= A::CAPACITY, 
-        "ArrayVec::append> total length {} exceeds capacity {}!",
-        new_len, A::CAPACITY
+    assert!(
+      new_len <= A::CAPACITY,
+      "ArrayVec::append> total length {} exceeds capacity {}!",
+      new_len,
+      A::CAPACITY
     );
 
     for item in other.drain(..) {
@@ -174,7 +176,10 @@ impl<A: Array> ArrayVec<A> {
   /// assert_eq!(av3, &[7, 8, 9][..]);
   /// ```
   #[inline]
-  pub fn try_append<'other>(&mut self, other: &'other mut Self) -> Option<&'other mut Self> {
+  pub fn try_append<'other>(
+    &mut self,
+    other: &'other mut Self,
+  ) -> Option<&'other mut Self> {
     let new_len = self.len() + other.len();
     if new_len > A::CAPACITY {
       return Some(other);
@@ -403,8 +408,8 @@ impl<A: Array> ArrayVec<A> {
     assert!(x.is_none(), "ArrayVec::insert> capacity overflow!");
   }
 
-  /// Tries to insert an item at the position given, moving all following elements +1
-  /// index.
+  /// Tries to insert an item at the position given, moving all following
+  /// elements +1 index.
   /// Returns back the element if the capacity is exhausted,
   /// otherwise returns None.
   ///
@@ -1507,4 +1512,3 @@ impl<A: Array> ArrayVec<A> {
     self.drain_to_vec_and_reserve(0)
   }
 }
-

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -746,7 +746,7 @@ impl<A: Array> ArrayVec<A> {
   /// ```rust
   /// use tinyvec::*;
   /// let mut av = array_vec!([i32; 4] => 1, 2, 3);
-  /// let av2: TinyVec<[i32; 4]> = av.splice(1.., 4..=6).collect();
+  /// let av2: ArrayVec<[i32; 4]> = av.splice(1.., 4..=6).collect();
   /// assert_eq!(av.as_slice(), &[1, 4, 5, 6][..]);
   /// assert_eq!(av2.as_slice(), &[2, 3][..]);
   ///

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -734,6 +734,9 @@ impl<A: Array> ArrayVec<A> {
   /// vector, yields the removed items, and replaces them with elements from
   /// the provided iterator.
   ///
+  /// `splice` fuses the provided iterator, so elements after the first `None`
+  /// are ignored.
+  ///
   /// ## Panics
   /// * If the start is greater than the end.
   /// * If the end is past the edge of the vec.
@@ -758,11 +761,10 @@ impl<A: Array> ArrayVec<A> {
     &mut self,
     range: R,
     replacement: I,
-  ) -> ArrayVecSplice<'_, A, I::IntoIter>
+  ) -> ArrayVecSplice<'_, A, core::iter::Fuse<I::IntoIter>>
   where
     R: RangeBounds<usize>,
     I: IntoIterator<Item = A::Item>,
-    I::IntoIter: FusedIterator,
   {
     use core::ops::Bound;
     let start = match range.start_bound() {
@@ -792,7 +794,7 @@ impl<A: Array> ArrayVec<A> {
       removal_start: start,
       removal_end: end,
       parent: self,
-      replacement: replacement.into_iter(),
+      replacement: replacement.into_iter().fuse(),
     }
   }
 

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -161,11 +161,12 @@ impl<A: Array> TinyVec<A> {
   /// assert!(tv.is_inline());
   /// ```
   pub fn shrink_to_fit(&mut self)
-  where A: Default,
+  where
+    A: Default,
   {
     let vec = match self {
       TinyVec::Inline(_) => return,
-      TinyVec::Heap(h)   => h,
+      TinyVec::Heap(h) => h,
     };
 
     if vec.len() > A::CAPACITY {
@@ -191,7 +192,7 @@ impl<A: Array> TinyVec<A> {
   #[allow(clippy::missing_inline_in_public_items)]
   pub fn move_to_the_heap(&mut self) {
     let arr = match self {
-      TinyVec::Heap(_)   => return,
+      TinyVec::Heap(_) => return,
       TinyVec::Inline(a) => a,
     };
 
@@ -211,10 +212,10 @@ impl<A: Array> TinyVec<A> {
   /// ```
   pub fn move_to_the_heap_and_reserve(&mut self, n: usize) {
     let arr = match self {
-      TinyVec::Heap(h)   => return h.reserve(n),
+      TinyVec::Heap(h) => return h.reserve(n),
       TinyVec::Inline(a) => a,
     };
-    
+
     let v = arr.drain_to_vec_and_reserve(n);
     *self = TinyVec::Heap(v);
   }
@@ -231,7 +232,7 @@ impl<A: Array> TinyVec<A> {
   /// ```
   pub fn reserve(&mut self, n: usize) {
     let arr = match self {
-      TinyVec::Heap(h)   => return h.reserve(n),
+      TinyVec::Heap(h) => return h.reserve(n),
       TinyVec::Inline(a) => a,
     };
 
@@ -250,7 +251,7 @@ impl<A: Array> TinyVec<A> {
   /// From [Vec::reserve_exact](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.reserve_exact)
   /// ```text
   /// Note that the allocator may give the collection more space than it requests.
-  /// Therefore, capacity can not be relied upon to be precisely minimal. 
+  /// Therefore, capacity can not be relied upon to be precisely minimal.
   /// Prefer reserve if future insertions are expected.
   /// ```
   /// ```rust
@@ -263,7 +264,7 @@ impl<A: Array> TinyVec<A> {
   /// ```
   pub fn reserve_exact(&mut self, n: usize) {
     let arr = match self {
-      TinyVec::Heap(h)   => return h.reserve_exact(n),
+      TinyVec::Heap(h) => return h.reserve_exact(n),
       TinyVec::Inline(a) => a,
     };
 
@@ -285,7 +286,7 @@ impl<A: Array> TinyVec<A> {
     let iter = other.drain(..);
 
     match self {
-      TinyVec::Heap(h)   => h.extend(iter),
+      TinyVec::Heap(h) => h.extend(iter),
       TinyVec::Inline(a) => a.extend(iter),
     }
   }
@@ -455,7 +456,7 @@ impl<A: Array> TinyVec<A> {
     self.reserve(sli.len());
     match self {
       TinyVec::Inline(a) => a.extend_from_slice(sli),
-      TinyVec::Heap(h)   => h.extend_from_slice(sli),
+      TinyVec::Heap(h) => h.extend_from_slice(sli),
     }
   }
 
@@ -505,19 +506,22 @@ impl<A: Array> TinyVec<A> {
   /// ```
   #[inline]
   pub fn insert(&mut self, index: usize, item: A::Item) {
-    assert!(index <= self.len(), 
-        "insertion index (is {}) should be <= len (is {})",
-        index, self.len()
+    assert!(
+      index <= self.len(),
+      "insertion index (is {}) should be <= len (is {})",
+      index,
+      self.len()
     );
 
     let arr = match self {
-      TinyVec::Heap(v)   => return v.insert(index, item),
+      TinyVec::Heap(v) => return v.insert(index, item),
       TinyVec::Inline(a) => a,
     };
 
     if let Some(x) = arr.try_insert(index, item) {
       let mut v = Vec::with_capacity(arr.len() * 2);
-      let mut it = arr.iter_mut().map(|r| core::mem::replace(r, Default::default()));
+      let mut it =
+        arr.iter_mut().map(|r| core::mem::replace(r, Default::default()));
       v.extend(it.by_ref().take(index));
       v.push(x);
       v.extend(it);
@@ -576,7 +580,7 @@ impl<A: Array> TinyVec<A> {
   #[inline(always)]
   pub fn push(&mut self, val: A::Item) {
     let arr = match self {
-      TinyVec::Heap(v)   => return v.push(val),
+      TinyVec::Heap(v) => return v.push(val),
       TinyVec::Inline(a) => a,
     };
 
@@ -663,13 +667,13 @@ impl<A: Array> TinyVec<A> {
   #[inline]
   pub fn resize_with<F: FnMut() -> A::Item>(&mut self, new_len: usize, f: F) {
     match new_len.checked_sub(self.len()) {
-      None    => return self.truncate(new_len),
+      None => return self.truncate(new_len),
       Some(n) => self.reserve(n),
     }
 
     match self {
       TinyVec::Inline(a) => a.resize_with(new_len, f),
-      TinyVec::Heap(v)   => v.resize_with(new_len, f),
+      TinyVec::Heap(v) => v.resize_with(new_len, f),
     }
   }
 
@@ -1011,19 +1015,19 @@ impl<A: Array> Extend<A::Item> for TinyVec<A> {
     let (lower_bound, _) = iter.size_hint();
     self.reserve(lower_bound);
 
-	let a = match self {
+    let a = match self {
       TinyVec::Heap(h) => return h.extend(iter),
       TinyVec::Inline(a) => a,
     };
-    
+
     let mut iter = a.fill(iter);
     let maybe = iter.next();
-    
+
     let surely = match maybe {
       Some(x) => x,
       None => return,
     };
-    
+
     let mut v = a.drain_to_vec_and_reserve(a.len());
     v.push(surely);
     v.extend(iter);

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -724,6 +724,9 @@ impl<A: Array> TinyVec<A> {
   /// vector, yields the removed items, and replaces them with elements from
   /// the provided iterator.
   ///
+  /// `splice` fuses the provided iterator, so elements after the first `None`
+  /// are ignored.
+  ///
   /// ## Panics
   /// * If the start is greater than the end.
   /// * If the end is past the edge of the vec.
@@ -745,11 +748,10 @@ impl<A: Array> TinyVec<A> {
     &mut self,
     range: R,
     replacement: I,
-  ) -> TinyVecSplice<'_, A, I::IntoIter>
+  ) -> TinyVecSplice<'_, A, core::iter::Fuse<I::IntoIter>>
   where
     R: RangeBounds<usize>,
     I: IntoIterator<Item = A::Item>,
-    I::IntoIter: FusedIterator,
   {
     use core::ops::Bound;
     let start = match range.start_bound() {
@@ -779,7 +781,7 @@ impl<A: Array> TinyVec<A> {
       removal_start: start,
       removal_end: end,
       parent: self,
-      replacement: replacement.into_iter(),
+      replacement: replacement.into_iter().fuse(),
     }
   }
 

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -962,7 +962,8 @@ impl<'p, A: Array, I: Iterator<Item = A::Item>> Drop
   fn drop(&mut self) {
     for _ in self.by_ref() {}
 
-    // FIXME: reserve lower bound of size_hint
+    let (lower_bound, _) = self.replacement.size_hint();
+    self.parent.reserve(lower_bound);
 
     for replacement in self.replacement.by_ref() {
       self.parent.insert(self.removal_end, replacement);

--- a/tests/arrayvec.rs
+++ b/tests/arrayvec.rs
@@ -184,3 +184,169 @@ fn ArrayVec_drain() {
   assert_eq!(Vec::from_iter(av.clone().drain(1..=1)), vec![2]);
   assert_eq!(Vec::from_iter(av.clone().drain(1..=2)), vec![2, 3]);
 }
+
+#[test]
+fn ArrayVec_splice() {
+  let mut av: ArrayVec<[i32; 10]> = Default::default();
+  av.push(1);
+  av.push(2);
+  av.push(3);
+
+  // splice returns the same things as drain
+  assert_eq!(Vec::from_iter(av.clone().splice(.., None)), vec![1, 2, 3]);
+
+  assert_eq!(Vec::from_iter(av.clone().splice(..2, None)), vec![1, 2]);
+  assert_eq!(Vec::from_iter(av.clone().splice(..3, None)), vec![1, 2, 3]);
+
+  assert_eq!(Vec::from_iter(av.clone().splice(..=1, None)), vec![1, 2]);
+  assert_eq!(Vec::from_iter(av.clone().splice(..=2, None)), vec![1, 2, 3]);
+
+  assert_eq!(Vec::from_iter(av.clone().splice(0.., None)), vec![1, 2, 3]);
+  assert_eq!(Vec::from_iter(av.clone().splice(1.., None)), vec![2, 3]);
+
+  assert_eq!(Vec::from_iter(av.clone().splice(0..2, None)), vec![1, 2]);
+  assert_eq!(Vec::from_iter(av.clone().splice(0..3, None)), vec![1, 2, 3]);
+  assert_eq!(Vec::from_iter(av.clone().splice(1..2, None)), vec![2]);
+  assert_eq!(Vec::from_iter(av.clone().splice(1..3, None)), vec![2, 3]);
+
+  assert_eq!(Vec::from_iter(av.clone().splice(0..=1, None)), vec![1, 2]);
+  assert_eq!(Vec::from_iter(av.clone().splice(0..=2, None)), vec![1, 2, 3]);
+  assert_eq!(Vec::from_iter(av.clone().splice(1..=1, None)), vec![2]);
+  assert_eq!(Vec::from_iter(av.clone().splice(1..=2, None)), vec![2, 3]);
+
+  // splice removes the same things as drain
+  let mut av2 = av.clone();
+  av2.splice(.., None);
+  assert_eq!(av2, array_vec![]);
+
+  let mut av2 = av.clone();
+  av2.splice(..2, None);
+  assert_eq!(av2, array_vec![3]);
+
+  let mut av2 = av.clone();
+  av2.splice(..3, None);
+  assert_eq!(av2, array_vec![]);
+
+  let mut av2 = av.clone();
+  av2.splice(..=1, None);
+  assert_eq!(av2, array_vec![3]);
+  let mut av2 = av.clone();
+  av2.splice(..=2, None);
+  assert_eq!(av2, array_vec![]);
+
+  let mut av2 = av.clone();
+  av2.splice(0.., None);
+  assert_eq!(av2, array_vec![]);
+  let mut av2 = av.clone();
+  av2.splice(1.., None);
+  assert_eq!(av2, array_vec![1]);
+
+  let mut av2 = av.clone();
+  av2.splice(0..2, None);
+  assert_eq!(av2, array_vec![3]);
+
+  let mut av2 = av.clone();
+  av2.splice(0..3, None);
+  assert_eq!(av2, array_vec![]);
+  let mut av2 = av.clone();
+  av2.splice(1..2, None);
+  assert_eq!(av2, array_vec![1, 3]);
+
+  let mut av2 = av.clone();
+  av2.splice(1..3, None);
+  assert_eq!(av2, array_vec![1]);
+
+  let mut av2 = av.clone();
+  av2.splice(0..=1, None);
+  assert_eq!(av2, array_vec![3]);
+
+  let mut av2 = av.clone();
+  av2.splice(0..=2, None);
+  assert_eq!(av2, array_vec![]);
+
+  let mut av2 = av.clone();
+  av2.splice(1..=1, None);
+  assert_eq!(av2, array_vec![1, 3]);
+
+  let mut av2 = av.clone();
+  av2.splice(1..=2, None);
+  assert_eq!(av2, array_vec![1]);
+
+  // splice adds the elements correctly
+  let mut av2 = av.clone();
+  av2.splice(.., 4..=6);
+  assert_eq!(av2, array_vec![4, 5, 6]);
+
+  let mut av2 = av.clone();
+  av2.splice(..2, 4..=6);
+  assert_eq!(av2, array_vec![4, 5, 6, 3]);
+
+  let mut av2 = av.clone();
+  av2.splice(..3, 4..=6);
+  assert_eq!(av2, array_vec![4, 5, 6]);
+
+  let mut av2 = av.clone();
+  av2.splice(..=1, 4..=6);
+  assert_eq!(av2, array_vec![4, 5, 6, 3]);
+
+  let mut av2 = av.clone();
+  av2.splice(..=2, 4..=6);
+  assert_eq!(av2, array_vec![4, 5, 6]);
+
+  let mut av2 = av.clone();
+  av2.splice(0.., 4..=6);
+  assert_eq!(av2, array_vec![4, 5, 6]);
+
+  let mut av2 = av.clone();
+  av2.splice(1.., 4..=6);
+  assert_eq!(av2, array_vec![1, 4, 5, 6]);
+
+  let mut av2 = av.clone();
+  av2.splice(0..2, 4..=6);
+  assert_eq!(av2, array_vec![4, 5, 6, 3]);
+
+  let mut av2 = av.clone();
+  av2.splice(0..3, 4..=6);
+  assert_eq!(av2, array_vec![4, 5, 6]);
+
+  let mut av2 = av.clone();
+  av2.splice(1..2, 4..=6);
+  assert_eq!(av2, array_vec![1, 4, 5, 6, 3]);
+
+  let mut av2 = av.clone();
+  av2.splice(1..3, 4..=6);
+  assert_eq!(av2, array_vec![1, 4, 5, 6]);
+
+  let mut av2 = av.clone();
+  av2.splice(0..=1, 4..=6);
+  assert_eq!(av2, array_vec![4, 5, 6, 3]);
+
+  let mut av2 = av.clone();
+  av2.splice(0..=2, 4..=6);
+  assert_eq!(av2, array_vec![4, 5, 6]);
+
+  let mut av2 = av.clone();
+  av2.splice(1..=1, 4..=6);
+  assert_eq!(av2, array_vec![1, 4, 5, 6, 3]);
+
+  let mut av2 = av.clone();
+  av2.splice(1..=2, 4..=6);
+  assert_eq!(av2, array_vec![1, 4, 5, 6]);
+
+  // splice adds the elements correctly when the replacement is smaller
+  let mut av2 = av.clone();
+  av2.splice(.., Some(4));
+  assert_eq!(av2, array_vec![4]);
+
+  let mut av2 = av.clone();
+  av2.splice(..2, Some(4));
+  assert_eq!(av2, array_vec![4, 3]);
+
+  let mut av2 = av.clone();
+  av2.splice(1.., Some(4));
+  assert_eq!(av2, array_vec![1, 4]);
+
+  let mut av2 = av.clone();
+  av2.splice(1..=1, Some(4));
+  assert_eq!(av2, array_vec![1, 4, 3]);
+}

--- a/tests/tinyvec.rs
+++ b/tests/tinyvec.rs
@@ -315,6 +315,5 @@ fn TinyVec_move_to_heap_and_shrink() {
   assert_eq!(tv.capacity(), 4);
   tv.extend(2..=4);
   assert_eq!(tv.capacity(), 4);
-  assert_eq!(tv.as_slice(), [1,2,3,4]);
+  assert_eq!(tv.as_slice(), [1, 2, 3, 4]);
 }
-

--- a/tests/tinyvec.rs
+++ b/tests/tinyvec.rs
@@ -61,6 +61,172 @@ fn TinyVec_drain() {
 }
 
 #[test]
+fn TinyVec_splice() {
+  let mut tv: TinyVec<[i32; 10]> = Default::default();
+  tv.push(1);
+  tv.push(2);
+  tv.push(3);
+
+  // splice returns the same things as drain
+  assert_eq!(Vec::from_iter(tv.clone().splice(.., None)), vec![1, 2, 3]);
+
+  assert_eq!(Vec::from_iter(tv.clone().splice(..2, None)), vec![1, 2]);
+  assert_eq!(Vec::from_iter(tv.clone().splice(..3, None)), vec![1, 2, 3]);
+
+  assert_eq!(Vec::from_iter(tv.clone().splice(..=1, None)), vec![1, 2]);
+  assert_eq!(Vec::from_iter(tv.clone().splice(..=2, None)), vec![1, 2, 3]);
+
+  assert_eq!(Vec::from_iter(tv.clone().splice(0.., None)), vec![1, 2, 3]);
+  assert_eq!(Vec::from_iter(tv.clone().splice(1.., None)), vec![2, 3]);
+
+  assert_eq!(Vec::from_iter(tv.clone().splice(0..2, None)), vec![1, 2]);
+  assert_eq!(Vec::from_iter(tv.clone().splice(0..3, None)), vec![1, 2, 3]);
+  assert_eq!(Vec::from_iter(tv.clone().splice(1..2, None)), vec![2]);
+  assert_eq!(Vec::from_iter(tv.clone().splice(1..3, None)), vec![2, 3]);
+
+  assert_eq!(Vec::from_iter(tv.clone().splice(0..=1, None)), vec![1, 2]);
+  assert_eq!(Vec::from_iter(tv.clone().splice(0..=2, None)), vec![1, 2, 3]);
+  assert_eq!(Vec::from_iter(tv.clone().splice(1..=1, None)), vec![2]);
+  assert_eq!(Vec::from_iter(tv.clone().splice(1..=2, None)), vec![2, 3]);
+
+  // splice removes the same things as drain
+  let mut tv2 = tv.clone();
+  tv2.splice(.., None);
+  assert_eq!(tv2, tiny_vec![]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(..2, None);
+  assert_eq!(tv2, tiny_vec![3]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(..3, None);
+  assert_eq!(tv2, tiny_vec![]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(..=1, None);
+  assert_eq!(tv2, tiny_vec![3]);
+  let mut tv2 = tv.clone();
+  tv2.splice(..=2, None);
+  assert_eq!(tv2, tiny_vec![]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(0.., None);
+  assert_eq!(tv2, tiny_vec![]);
+  let mut tv2 = tv.clone();
+  tv2.splice(1.., None);
+  assert_eq!(tv2, tiny_vec![1]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(0..2, None);
+  assert_eq!(tv2, tiny_vec![3]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(0..3, None);
+  assert_eq!(tv2, tiny_vec![]);
+  let mut tv2 = tv.clone();
+  tv2.splice(1..2, None);
+  assert_eq!(tv2, tiny_vec![1, 3]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(1..3, None);
+  assert_eq!(tv2, tiny_vec![1]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(0..=1, None);
+  assert_eq!(tv2, tiny_vec![3]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(0..=2, None);
+  assert_eq!(tv2, tiny_vec![]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(1..=1, None);
+  assert_eq!(tv2, tiny_vec![1, 3]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(1..=2, None);
+  assert_eq!(tv2, tiny_vec![1]);
+
+  // splice adds the elements correctly
+  let mut tv2 = tv.clone();
+  tv2.splice(.., 4..=6);
+  assert_eq!(tv2, tiny_vec![4, 5, 6]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(..2, 4..=6);
+  assert_eq!(tv2, tiny_vec![4, 5, 6, 3]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(..3, 4..=6);
+  assert_eq!(tv2, tiny_vec![4, 5, 6]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(..=1, 4..=6);
+  assert_eq!(tv2, tiny_vec![4, 5, 6, 3]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(..=2, 4..=6);
+  assert_eq!(tv2, tiny_vec![4, 5, 6]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(0.., 4..=6);
+  assert_eq!(tv2, tiny_vec![4, 5, 6]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(1.., 4..=6);
+  assert_eq!(tv2, tiny_vec![1, 4, 5, 6]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(0..2, 4..=6);
+  assert_eq!(tv2, tiny_vec![4, 5, 6, 3]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(0..3, 4..=6);
+  assert_eq!(tv2, tiny_vec![4, 5, 6]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(1..2, 4..=6);
+  assert_eq!(tv2, tiny_vec![1, 4, 5, 6, 3]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(1..3, 4..=6);
+  assert_eq!(tv2, tiny_vec![1, 4, 5, 6]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(0..=1, 4..=6);
+  assert_eq!(tv2, tiny_vec![4, 5, 6, 3]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(0..=2, 4..=6);
+  assert_eq!(tv2, tiny_vec![4, 5, 6]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(1..=1, 4..=6);
+  assert_eq!(tv2, tiny_vec![1, 4, 5, 6, 3]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(1..=2, 4..=6);
+  assert_eq!(tv2, tiny_vec![1, 4, 5, 6]);
+
+  // splice adds the elements correctly when the replacement is smaller
+  let mut tv2 = tv.clone();
+  tv2.splice(.., Some(4));
+  assert_eq!(tv2, tiny_vec![4]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(..2, Some(4));
+  assert_eq!(tv2, tiny_vec![4, 3]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(1.., Some(4));
+  assert_eq!(tv2, tiny_vec![1, 4]);
+
+  let mut tv2 = tv.clone();
+  tv2.splice(1..=1, Some(4));
+  assert_eq!(tv2, tiny_vec![1, 4, 3]);
+}
+
+#[test]
 fn TinyVec_resize() {
   let mut tv: TinyVec<[i32; 10]> = Default::default();
   tv.resize(20, 5);


### PR DESCRIPTION
Added for closer API parity to `std::Vec`

Closes #50.