### PR TITLE
A bit of everything for iterators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,11 @@ experimental_write_impl = []
 # small size without allocation.
 experimental_array_set = []
 
+# features that require rustc 1.40
+# use Vec::append if possible in TinyVec::append - 1.37
+# DoubleEndedIterator::nth_back - 1.40
+rustc_1_40 = []
+
 [badges]
 appveyor = { repository = "Lokathor/tinyvec" }
 travis-ci = { repository = "Lokathor/tinyvec" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 tinyvec = { path = "..", features = ["alloc", "nightly_slice_partition_dedup"] }
-arbitrary-model-tests = { git = "https://github.com/jakubadamw/arbitrary-model-tests" }
+rutenspitz = "0.2"
 honggfuzz = "0.5.45"
 arbitrary = "0.2.0"
 better-panic = "0.2.0"

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -146,16 +146,12 @@ impl<A: Array> ArrayVec<A> {
   /// ```
   #[inline]
   pub fn append(&mut self, other: &mut Self) {
-    let new_len = self.len() + other.len();
     assert!(
-      new_len <= A::CAPACITY,
+      self.try_append(other).is_none(),
       "ArrayVec::append> total length {} exceeds capacity {}!",
-      new_len,
+      self.len() + other.len(),
       A::CAPACITY
     );
-
-    let x = self.try_append(other);
-    debug_assert!(x.is_none());
   }
 
   /// Move all values from `other` into this vec.

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1210,6 +1210,10 @@ impl<A: Array> DoubleEndedIterator for ArrayVecIterator<A> {
     self.len -= 1;
     return Some(take(item));
   }
+  /* @Soveu: nth_back is stable from 1.37
+   * If minimal version of rust gets updated, uncomment this code
+   */
+  /*
   #[inline]
   fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
     let slice = &mut self.data.as_slice_mut()[self.base..self.len];
@@ -1219,6 +1223,7 @@ impl<A: Array> DoubleEndedIterator for ArrayVecIterator<A> {
 
     return Some(take(item));
   }
+  */
 }
 
 impl<A: Array> Debug for ArrayVecIterator<A>

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -154,9 +154,8 @@ impl<A: Array> ArrayVec<A> {
       A::CAPACITY
     );
 
-    for item in other.drain(..) {
-      self.push(item);
-    }
+    let x = self.try_append(other);
+    debug_assert!(x.is_none());
   }
 
   /// Move all values from `other` into this vec.
@@ -185,9 +184,12 @@ impl<A: Array> ArrayVec<A> {
       return Some(other);
     }
 
-    for item in other.drain(..) {
+    let iter = other.into_iter().map(take);
+    for item in iter {
       self.push(item);
     }
+
+    other.set_len(0);
 
     return None;
   }
@@ -1496,7 +1498,9 @@ impl<A: Array> ArrayVec<A> {
   pub fn drain_to_vec_and_reserve(&mut self, n: usize) -> Vec<A::Item> {
     let cap = n + self.len();
     let mut v = Vec::with_capacity(cap);
-    v.extend(self.drain(..));
+    let iter = self.into_iter().map(take);
+    v.extend(iter);
+    self.set_len(0);
     return v;
   }
 

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1144,10 +1144,7 @@ impl<A: Array> DoubleEndedIterator for ArrayVecIterator<A> {
     self.len -= 1;
     return Some(take(item));
   }
-  /* @Soveu: nth_back is stable from 1.37
-   * If minimal version of rust gets updated, uncomment this code
-   */
-  /*
+  #[cfg(feature = "rustc_1_40")]
   #[inline]
   fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
     let slice = &mut self.data.as_slice_mut()[self.base..self.len];
@@ -1157,7 +1154,6 @@ impl<A: Array> DoubleEndedIterator for ArrayVecIterator<A> {
 
     return Some(take(item));
   }
-  */
 }
 
 impl<A: Array> Debug for ArrayVecIterator<A>

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -496,11 +496,14 @@ impl<A: Array> ArrayVec<A> {
   /// ```
   #[inline(always)]
   pub fn try_push(&mut self, val: A::Item) -> Option<A::Item> {
-    if self.len == A::CAPACITY {
-      return Some(val);
-    }
+    debug_assert!(self.len <= A::CAPACITY);
 
-    self.data.as_slice_mut()[self.len] = val;
+    let itemref = match self.data.as_slice_mut().get_mut(self.len) {
+      None => return Some(val),
+      Some(x) => x,
+    };
+
+    *itemref = val;
     self.len += 1;
     return None;
   }

--- a/src/arrayvec_drain.rs
+++ b/src/arrayvec_drain.rs
@@ -59,11 +59,11 @@ impl<'a, T: 'a + Default> DoubleEndedIterator for ArrayVecDrain<'a, T> {
   fn next_back(&mut self) -> Option<Self::Item> {
     self.iter.next_back().map(take)
   }
-  /*
+
+  #[cfg(feature = "rustc_1_40")]
   fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-      self.iter.nth_back(n).map(take)
+    self.iter.nth_back(n).map(take)
   }
-  */
 }
 
 impl<'a, T: 'a + Default> Iterator for ArrayVecDrain<'a, T> {

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+use core::{
+  ops::{Bound, RangeBounds},
+  slice,
+};
+
+/// Draining iterator for [`ArrayVec`]
+///
+/// See [`ArrayVec::drain`](ArrayVec::drain)
+pub struct ArrayVecDrain<'a, T: 'a + Default> {
+  iter: slice::IterMut<'a, T>,
+}
+
+impl<'a, T: 'a + Default> ArrayVecDrain<'a, T> {
+  pub(crate) fn new<A, R>(arr: &'a mut ArrayVec<A>, range: R) -> Self
+  where
+    A: Array<Item = T>,
+    R: RangeBounds<usize>,
+  {
+    let start = match range.start_bound() {
+      Bound::Unbounded => 0,
+      Bound::Included(&n) => n,
+      Bound::Excluded(&n) => n + 1,
+    };
+    let end = match range.end_bound() {
+      Bound::Unbounded => arr.len(),
+      Bound::Included(&n) => n + 1,
+      Bound::Excluded(&n) => n,
+    };
+
+    assert!(
+      start <= end,
+      "ArrayVec::drain> Illegal range, {} to {}",
+      start,
+      end
+    );
+    assert!(
+      end <= arr.len(),
+      "ArrayVec::drain> Range ends at {}, but length is only {}",
+      end,
+      arr.len()
+    );
+
+    let len = end - start;
+    let to_rotate = &mut arr[start..];
+    to_rotate.rotate_left(len);
+
+    let oldlen = arr.len();
+    let newlen = oldlen - len;
+    arr.set_len(newlen);
+    let slice = &mut arr.data.as_slice_mut()[newlen..oldlen];
+    let iter = slice.iter_mut();
+    Self { iter }
+  }
+}
+
+impl<'a, T: 'a + Default> DoubleEndedIterator for ArrayVecDrain<'a, T> {
+  fn next_back(&mut self) -> Option<Self::Item> {
+    self.iter.next_back().map(take)
+  }
+  /*
+  fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+      self.iter.nth_back(n).map(take)
+  }
+  */
+}
+
+impl<'a, T: 'a + Default> Iterator for ArrayVecDrain<'a, T> {
+  type Item = T;
+  fn next(&mut self) -> Option<Self::Item> {
+    self.iter.next().map(take)
+  }
+  fn size_hint(&self) -> (usize, Option<usize>) {
+    self.iter.size_hint()
+  }
+  fn nth(&mut self, n: usize) -> Option<Self::Item> {
+    self.iter.nth(n).map(take)
+  }
+  fn last(self) -> Option<Self::Item> {
+    self.iter.last().map(take)
+  }
+  fn for_each<F>(self, f: F)
+  where
+    F: FnMut(Self::Item),
+  {
+    self.iter.map(take).for_each(f)
+  }
+}
+
+impl<'a, T: 'a + Default> FusedIterator for ArrayVecDrain<'a, T> {}
+impl<'a, T: 'a + Default> ExactSizeIterator for ArrayVecDrain<'a, T> {}
+/* No need to impl Drop! */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,9 @@ pub use arrayset::*;
 mod arrayvec;
 pub use arrayvec::*;
 
+mod drain;
+pub use drain::*;
+
 mod slicevec;
 pub use slicevec::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,8 @@ pub use arrayset::*;
 mod arrayvec;
 pub use arrayvec::*;
 
-mod drain;
-pub use drain::*;
+mod arrayvec_drain;
+pub use arrayvec_drain::*;
 
 mod slicevec;
 pub use slicevec::*;

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -282,12 +282,15 @@ impl<A: Array> TinyVec<A> {
   /// Move all values from `other` into this vec.
   #[inline]
   pub fn append(&mut self, other: &mut Self) {
-    match other {
-      TinyVec::Heap(h) => self.extend(h.drain(..)),
-      TinyVec::Inline(a) => {
-        let iter = a.into_iter().map(take);
-        self.extend(iter);
-        a.set_len(0);
+    self.reserve(other.len());
+
+    match (self, other) {
+      (TinyVec::Heap(sh), TinyVec::Heap(oh)) => sh.append(oh),
+      (TinyVec::Inline(a), TinyVec::Heap(h)) => a.extend(h.drain(..)),
+      (ref mut this, TinyVec::Inline(arr)) => {
+        let iter = arr.iter_mut().map(take);
+        this.extend(iter);
+        arr.set_len(0);
       }
     }
   }

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -282,12 +282,13 @@ impl<A: Array> TinyVec<A> {
   /// Move all values from `other` into this vec.
   #[inline]
   pub fn append(&mut self, other: &mut Self) {
-    self.reserve(other.len());
-    let iter = other.drain(..);
-
-    match self {
-      TinyVec::Heap(h) => h.extend(iter),
-      TinyVec::Inline(a) => a.extend(iter),
+    match other {
+      TinyVec::Heap(h) => self.extend(h.drain(..)),
+      TinyVec::Inline(a) => {
+        let iter = a.into_iter().map(take);
+        self.extend(iter);
+        a.set_len(0);
+      }
     }
   }
 

--- a/tests/arrayvec.rs
+++ b/tests/arrayvec.rs
@@ -376,6 +376,7 @@ fn iter_last_nth() {
 }
 
 #[test]
+#[cfg(feature = "rustc_1_40")]
 fn reviter() {
   let mut av: ArrayVec<[i32; 10]> = Default::default();
   av.push(1);
@@ -392,10 +393,6 @@ fn reviter() {
   assert_eq!(iter.next(), None);
   assert_eq!(iter.next_back(), None);
 
-  /* @Soveu: nth_back is stable from 1.37
-   * If minimal version of rust gets updated, uncomment this code
-   */
-  /*
   let mut av: ArrayVec<[i32; 10]> = Default::default();
   av.push(1);
   av.push(2);
@@ -408,5 +405,4 @@ fn reviter() {
   assert_eq!(iter.nth_back(2), Some(1));
   assert_eq!(iter.nth_back(0), None);
   assert_eq!(iter.nth_back(99), None);
-  */
 }

--- a/tests/arrayvec.rs
+++ b/tests/arrayvec.rs
@@ -392,6 +392,10 @@ fn reviter() {
   assert_eq!(iter.next(), None);
   assert_eq!(iter.next_back(), None);
 
+  /* @Soveu: nth_back is stable from 1.37
+   * If minimal version of rust gets updated, uncomment this code
+   */
+  /*
   let mut av: ArrayVec<[i32; 10]> = Default::default();
   av.push(1);
   av.push(2);
@@ -404,4 +408,5 @@ fn reviter() {
   assert_eq!(iter.nth_back(2), Some(1));
   assert_eq!(iter.nth_back(0), None);
   assert_eq!(iter.nth_back(99), None);
+  */
 }

--- a/tests/arrayvec.rs
+++ b/tests/arrayvec.rs
@@ -350,3 +350,28 @@ fn ArrayVec_splice() {
   av2.splice(1..=1, Some(4));
   assert_eq!(av2, array_vec![1, 4, 3]);
 }
+
+#[test]
+fn iter_last_nth() {
+  let mut av: ArrayVec<[i32; 10]> = Default::default();
+  av.push(1);
+  av.push(2);
+  av.push(3);
+  av.push(4);
+  assert_eq!(av.len(), 4);
+  let mut iter = av.into_iter();
+  assert_eq!(iter.next(), Some(1));
+  assert_eq!(iter.next(), Some(2));
+  assert_eq!(iter.next(), Some(3));
+  assert_eq!(iter.next(), Some(4));
+  assert_eq!(iter.next(), None);
+  assert_eq!(iter.last(), None);
+
+  let mut av: ArrayVec<[i32; 10]> = Default::default();
+  av.push(1);
+  av.push(2);
+  av.push(3);
+
+  assert_eq!(av.into_iter().nth(0), Some(1));
+}
+

--- a/tests/arrayvec.rs
+++ b/tests/arrayvec.rs
@@ -375,3 +375,33 @@ fn iter_last_nth() {
   assert_eq!(av.into_iter().nth(0), Some(1));
 }
 
+#[test]
+fn reviter() {
+  let mut av: ArrayVec<[i32; 10]> = Default::default();
+  av.push(1);
+  av.push(2);
+  av.push(3);
+  av.push(4);
+
+  let mut iter = av.into_iter();
+
+  assert_eq!(iter.next(), Some(1));
+  assert_eq!(iter.next_back(), Some(4));
+  assert_eq!(iter.next(), Some(2));
+  assert_eq!(iter.next_back(), Some(3));
+  assert_eq!(iter.next(), None);
+  assert_eq!(iter.next_back(), None);
+
+  let mut av: ArrayVec<[i32; 10]> = Default::default();
+  av.push(1);
+  av.push(2);
+  av.push(3);
+  av.push(4);
+
+  let mut iter = av.into_iter();
+
+  assert_eq!(iter.nth_back(0), Some(4));
+  assert_eq!(iter.nth_back(2), Some(1));
+  assert_eq!(iter.nth_back(0), None);
+  assert_eq!(iter.nth_back(99), None);
+}


### PR DESCRIPTION
`into_iter().map(take)` on ArrayVec is equivalent to `.drain(..)` with exception to that `drain(..)` effectively does `set_len(0)` at the end.
Also, while looking at the implementation of ArrayVecIterator, I had a bad gut feeling about the current implementation, so I made additional tests.
Aaaaand there were bugs in `nth` (off-by-one?) and `last` (returns value even if iterator is exhausted)
By the way of fixing `Iterator` I also implemented `DoubleEndedIterator`