### PR TITLE
Arrayset overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,10 @@ criterion = "0.3.0"
 name = "tinyvec"
 required-features = ["alloc"]
 
+[[test]]
+name = "arrayset"
+required-features = ["experimental_array_set"]
+
 [[bench]]
 name = "macros"
 harness = false

--- a/src/arrayset.rs
+++ b/src/arrayset.rs
@@ -3,7 +3,6 @@
 // This was contributed by user `dhardy`! Big thanks.
 
 use super::{Array, ArrayVec};
-use core::fmt;
 
 /// An array-backed set
 ///
@@ -12,15 +11,17 @@ use core::fmt;
 ///
 /// The item type must support `Default`.
 #[derive(Clone, Default)]
-pub struct ArraySet<A: Array> 
-where A::Item: Default + Eq,
+pub struct ArraySet<A: Array>
+where
+  A::Item: Default + Eq,
 {
   /// The underlying ArrayVec
   pub arr: ArrayVec<A>,
 }
 
 impl<A: Array> ArraySet<A>
-where A::Item: Default + Eq,
+where
+  A::Item: Default + Eq,
 {
   /// Returns the fixed capacity of the set
   #[inline]
@@ -54,7 +55,7 @@ where A::Item: Default + Eq,
 
   /// Check whether the set contains `elt`
   #[inline]
-  pub fn contains<Q>(&self, elt: &Q) -> bool 
+  pub fn contains<Q>(&self, elt: &Q) -> bool
   where
     A::Item: PartialEq<Q>,
   {
@@ -97,7 +98,7 @@ where A::Item: Default + Eq,
 
     return match self.arr.try_push(elt) {
       Some(x) => Err(x),
-      None    => Ok(true),
+      None => Ok(true),
     };
   }
 
@@ -126,22 +127,26 @@ where A::Item: Default + Eq,
 
     return match self.arr.try_push(elt) {
       Some(x) => Err(x),
-      None    => Ok(None),
+      None => Ok(None),
     };
   }
 
   /// Same as `try_insert`, but unwraps for you
   pub fn insert(&mut self, elt: A::Item) -> bool {
     match self.try_insert(elt) {
-      Err(_) => panic!("ArraySet::insert> tried to insert, but capacity is exhausted"),
-      Ok(x)  => x,
+      Err(_) => {
+        panic!("ArraySet::insert> tried to insert, but capacity is exhausted")
+      }
+      Ok(x) => x,
     }
   }
   /// Same as `try_replace`, but unwraps for you
   pub fn replace(&mut self, elt: A::Item) -> Option<A::Item> {
     match self.try_replace(elt) {
-      Err(_) => panic!("ArraySet::replace> tried to replace, but capacity is exhausted"),
-      Ok(x)  => x,
+      Err(_) => {
+        panic!("ArraySet::replace> tried to replace, but capacity is exhausted")
+      }
+      Ok(x) => x,
     }
   }
 }

--- a/src/arrayset.rs
+++ b/src/arrayset.rs
@@ -75,8 +75,16 @@ where
   where
     A::Item: PartialEq<Q>,
   {
-    let (n, _) = self.iter().enumerate().find(|(_, x)| *x == elt)?;
-    Some(self.arr.remove(n))
+    let mut iter = self.arr.iter_mut();
+    let itemref = iter.find(|x| *x == elt)?;
+    let slice = iter.into_slice();
+
+    if let Some(first) = slice.first_mut() {
+      core::mem::swap(itemref, first);
+    }
+    slice.rotate_left(1);
+
+    self.arr.pop()
   }
 
   /// Remove any items for which `f(item) == false`

--- a/tests/arrayset.rs
+++ b/tests/arrayset.rs
@@ -1,0 +1,43 @@
+#![allow(bad_style)]
+
+use core::mem::size_of;
+use tinyvec::{ArraySet, InsertError};
+
+#[test]
+fn ArraySet_test_size() {
+  assert_eq!(size_of::<ArraySet<[i8; 7], u8>>(), 8);
+}
+
+#[test]
+fn ArraySet_test() {
+  let mut set: ArraySet<[i8; 7], u8> = ArraySet::new();
+  assert_eq!(set.capacity(), 7);
+
+  assert_eq!(set.try_insert(1), Ok(true));
+  assert_eq!(set.try_insert(5), Ok(true));
+  assert_eq!(set.try_insert(6), Ok(true));
+  assert_eq!(set.len(), 3);
+
+  assert_eq!(set.try_insert(5), Ok(false));
+  assert_eq!(set.len(), 3);
+
+  assert_eq!(set.try_replace(1), Ok(Some(1)));
+  assert_eq!(set.try_replace(2), Ok(None));
+  assert_eq!(set.len(), 4);
+
+  assert_eq!(set.try_insert(3), Ok(true));
+  assert_eq!(set.try_insert(4), Ok(true));
+  assert_eq!(set.try_insert(7), Ok(true));
+  assert_eq!(set.try_insert(8), Err(InsertError));
+  assert_eq!(set.len(), 7);
+
+  assert_eq!(set.try_replace(9), Err(InsertError));
+
+  assert_eq!(set.remove(&3), Some(3));
+  assert_eq!(set.len(), 6);
+
+  set.retain(|x| *x == 3 || *x == 6);
+  assert_eq!(set.len(), 1);
+  assert!(!set.contains(&3));
+  assert!(set.contains(&6));
+}

--- a/tests/arrayset.rs
+++ b/tests/arrayset.rs
@@ -1,16 +1,10 @@
 #![allow(bad_style)]
 
-use core::mem::size_of;
-use tinyvec::{ArraySet, InsertError};
-
-#[test]
-fn ArraySet_test_size() {
-  assert_eq!(size_of::<ArraySet<[i8; 7], u8>>(), 8);
-}
+use tinyvec::ArraySet;
 
 #[test]
 fn ArraySet_test() {
-  let mut set: ArraySet<[i8; 7], u8> = ArraySet::new();
+  let mut set: ArraySet<[i8; 7]> = ArraySet::default();
   assert_eq!(set.capacity(), 7);
 
   assert_eq!(set.try_insert(1), Ok(true));
@@ -28,10 +22,10 @@ fn ArraySet_test() {
   assert_eq!(set.try_insert(3), Ok(true));
   assert_eq!(set.try_insert(4), Ok(true));
   assert_eq!(set.try_insert(7), Ok(true));
-  assert_eq!(set.try_insert(8), Err(InsertError));
+  assert_eq!(set.try_insert(8), Err(8));
   assert_eq!(set.len(), 7);
 
-  assert_eq!(set.try_replace(9), Err(InsertError));
+  assert_eq!(set.try_replace(9), Err(9));
 
   assert_eq!(set.remove(&3), Some(3));
   assert_eq!(set.len(), 6);


### PR DESCRIPTION
Previous `ArraySet` did re-implement most of stuff that already existed in `ArrayVec`
The interface is now more close to the set interface from std (no `Result<Thing, InsertError>`), making it easier to fuzz 
(fuzzer is yet to be implemented)
Added `try_` functions as in `ArrayVec`
