### PR TITLE
Add Serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,14 @@ repository = "https://github.com/Lokathor/tinyvec"
 
 [dependencies]
 tinyvec_macros = { version = "0.1", optional = true }
+# Provides `Serialize` and `Deserialize` implementations
+serde = { version = "1.0", optional = true, default-features = false }
 
 [features]
 default = []
 
 # Provide things that utilize the `alloc` crate, namely `TinyVec`.
-alloc = ["tinyvec_macros"]
+alloc = ["tinyvec_macros", "serde/alloc"]
 
 # (not part of Vec!) Extra methods to let you grab the slice of memory after the
 # "active" portion of an `ArrayVec` or `SliceVec`.
@@ -53,6 +55,7 @@ members = ["fuzz"]
 
 [dev-dependencies]
 criterion = "0.3.0"
+serde_test = "1.0"
 
 [[test]]
 name = "tinyvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tinyvec_macros = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, default-features = false }
 
 [features]
-default = ["serde"]
+default = []
 
 # Provide things that utilize the `alloc` crate, namely `TinyVec`.
 alloc = ["tinyvec_macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tinyvec_macros = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, default-features = false }
 
 [features]
-default = []
+default = ["serde"]
 
 # Provide things that utilize the `alloc` crate, namely `TinyVec`.
 alloc = ["tinyvec_macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", optional = true, default-features = false }
 default = []
 
 # Provide things that utilize the `alloc` crate, namely `TinyVec`.
-alloc = ["tinyvec_macros", "serde/alloc"]
+alloc = ["tinyvec_macros"]
 
 # (not part of Vec!) Extra methods to let you grab the slice of memory after the
 # "active" portion of an `ArrayVec` or `SliceVec`.

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1564,9 +1564,13 @@ where
   where
     S: SeqAccess<'de>,
   {
-    let mut new_arrayvec: ArrayVec<A> = ArrayVec::new();
+    let mut new_arrayvec: ArrayVec<A> = Default::default();
 
     while let Some(value) = seq.next_element()? {
+      // Prefer to truncate rather than panic.
+      if new_arrayvec.len() >= new_arrayvec.capacity() {
+        break;
+      }
       new_arrayvec.push(value);
     }
 

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -4,7 +4,9 @@ use core::convert::TryInto;
 #[cfg(feature = "serde")]
 use core::marker::PhantomData;
 #[cfg(feature = "serde")]
-use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+use serde::de::{
+  Deserialize, Deserializer, Error as DeserializeError, SeqAccess, Visitor,
+};
 #[cfg(feature = "serde")]
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 
@@ -1566,12 +1568,13 @@ where
   {
     let mut new_arrayvec: ArrayVec<A> = Default::default();
 
+    let mut idx = 0usize;
     while let Some(value) = seq.next_element()? {
-      // Prefer to truncate rather than panic.
       if new_arrayvec.len() >= new_arrayvec.capacity() {
-        break;
+        return Err(DeserializeError::invalid_length(idx, &self));
       }
       new_arrayvec.push(value);
+      idx = idx + 1;
     }
 
     Ok(new_arrayvec)

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1,6 +1,13 @@
 use super::*;
 use core::convert::TryInto;
 
+#[cfg(feature = "serde")]
+use core::marker::PhantomData;
+#[cfg(feature = "serde")]
+use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+#[cfg(feature = "serde")]
+use serde::ser::{Serialize, SerializeSeq, Serializer};
+
 /// Helper to make an `ArrayVec`.
 ///
 /// You specify the backing array type, and optionally give all the elements you
@@ -127,6 +134,38 @@ impl<A: Array, I: SliceIndex<[A::Item]>> IndexMut<I> for ArrayVec<A> {
   #[must_use]
   fn index_mut(&mut self, index: I) -> &mut Self::Output {
     &mut self.deref_mut()[index]
+  }
+}
+
+#[cfg(feature = "serde")]
+impl<A: Array> Serialize for ArrayVec<A>
+where
+  A::Item: Serialize,
+{
+  #[must_use]
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut seq = serializer.serialize_seq(Some(self.len()))?;
+    for element in self.iter() {
+      seq.serialize_element(element)?;
+    }
+    seq.end()
+  }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, A: Array> Deserialize<'de> for ArrayVec<A>
+where
+  A: Default,
+  A::Item: Deserialize<'de>,
+{
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    deserializer.deserialize_seq(ArrayVecVisitor(PhantomData))
   }
 }
 
@@ -1500,5 +1539,37 @@ impl<A: Array> ArrayVec<A> {
   /// ```
   pub fn drain_to_vec(&mut self) -> Vec<A::Item> {
     self.drain_to_vec_and_reserve(0)
+  }
+}
+
+#[cfg(feature = "serde")]
+struct ArrayVecVisitor<A: Array>(PhantomData<A>);
+
+#[cfg(feature = "serde")]
+impl<'de, A: Array> Visitor<'de> for ArrayVecVisitor<A>
+where
+  A: Default,
+  A::Item: Deserialize<'de>,
+{
+  type Value = ArrayVec<A>;
+
+  fn expecting(
+    &self,
+    formatter: &mut core::fmt::Formatter,
+  ) -> core::fmt::Result {
+    formatter.write_str("a sequence")
+  }
+
+  fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+  where
+    S: SeqAccess<'de>,
+  {
+    let mut new_arrayvec: ArrayVec<A> = ArrayVec::new();
+
+    while let Some(value) = seq.next_element()? {
+      new_arrayvec.push(value);
+    }
+
+    Ok(new_arrayvec)
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@
 //!   ArrayVec.
 //! * `rustc_1_40` makes the crate assume a minimum rust version of `1.40.0`,
 //!   which allows some better internal optimizations.
+//! * `serde` provides a `Serialize` and `Deserialize` implementation for
+//!   [`TinyVec`] and [`ArrayVec`] types, provided the inner item also
+//!   has an implementation.
 //!
 //! ## API
 //! The general goal of the crate is that, as much as possible, the vecs here

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -1473,8 +1473,10 @@ where
   where
     S: SeqAccess<'de>,
   {
-    let expected_size = seq.size_hint().unwrap_or(0);
-    let mut new_tinyvec: TinyVec<A> = TinyVec::with_capacity(expected_size);
+    let mut new_tinyvec = match seq.size_hint() {
+      Some(expected_size) => TinyVec::with_capacity(expected_size),
+      None => Default::default(),
+    };
 
     while let Some(value) = seq.next_element()? {
       new_tinyvec.push(value);

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -1473,12 +1473,13 @@ where
   where
     S: SeqAccess<'de>,
   {
-    let mut new_arrayvec: ArrayVec<A> = ArrayVec::new();
+    let expected_size = seq.size_hint().unwrap_or(0);
+    let mut new_tinyvec: TinyVec<A> = TinyVec::with_capacity(expected_size);
 
     while let Some(value) = seq.next_element()? {
-      new_arrayvec.push(value);
+      new_tinyvec.push(value);
     }
 
-    Ok(TinyVec::Inline(new_arrayvec))
+    Ok(new_tinyvec)
   }
 }

--- a/tests/arrayvec.rs
+++ b/tests/arrayvec.rs
@@ -1,9 +1,9 @@
 #![allow(bad_style)]
 
-use std::iter::FromIterator;
-use tinyvec::*;
 #[cfg(feature = "serde")]
 use serde_test::{assert_tokens, Token};
+use std::iter::FromIterator;
+use tinyvec::*;
 
 #[test]
 fn test_a_vec() {
@@ -411,12 +411,8 @@ fn reviter() {
 #[test]
 fn ArrayVec_ser_de_empty() {
   let tv: ArrayVec<[i32; 0]> = Default::default();
-  
-  assert_tokens(&tv, &[
-    Token::Seq { len: Some(0) },
 
-    Token::SeqEnd,
-]);
+  assert_tokens(&tv, &[Token::Seq { len: Some(0) }, Token::SeqEnd]);
 }
 
 #[cfg(feature = "serde")]
@@ -427,15 +423,16 @@ fn ArrayVec_ser_de() {
   tv.push(2);
   tv.push(3);
   tv.push(4);
-  
-  assert_tokens(&tv, &[
-    Token::Seq { len: Some(4) },
 
-    Token::I32(1),
-    Token::I32(2),
-    Token::I32(3),
-    Token::I32(4),
-
-    Token::SeqEnd,
-]);
+  assert_tokens(
+    &tv,
+    &[
+      Token::Seq { len: Some(4) },
+      Token::I32(1),
+      Token::I32(2),
+      Token::I32(3),
+      Token::I32(4),
+      Token::SeqEnd,
+    ],
+  );
 }

--- a/tests/arrayvec.rs
+++ b/tests/arrayvec.rs
@@ -2,6 +2,8 @@
 
 use std::iter::FromIterator;
 use tinyvec::*;
+#[cfg(feature = "serde")]
+use serde_test::{assert_tokens, Token};
 
 #[test]
 fn test_a_vec() {
@@ -403,4 +405,37 @@ fn reviter() {
   assert_eq!(iter.nth_back(0), Some(27));
   assert_eq!(iter.nth_back(99), None);
   assert_eq!(iter.nth_back(99), None);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn ArrayVec_ser_de_empty() {
+  let tv: ArrayVec<[i32; 0]> = Default::default();
+  
+  assert_tokens(&tv, &[
+    Token::Seq { len: Some(0) },
+
+    Token::SeqEnd,
+]);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn ArrayVec_ser_de() {
+  let mut tv: ArrayVec<[i32; 4]> = Default::default();
+  tv.push(1);
+  tv.push(2);
+  tv.push(3);
+  tv.push(4);
+  
+  assert_tokens(&tv, &[
+    Token::Seq { len: Some(4) },
+
+    Token::I32(1),
+    Token::I32(2),
+    Token::I32(3),
+    Token::I32(4),
+
+    Token::SeqEnd,
+]);
 }

--- a/tests/tinyvec.rs
+++ b/tests/tinyvec.rs
@@ -2,10 +2,10 @@
 #![allow(bad_style)]
 #![allow(clippy::redundant_clone)]
 
-use std::iter::FromIterator;
-use tinyvec::*;
 #[cfg(feature = "serde")]
 use serde_test::{assert_tokens, Token};
+use std::iter::FromIterator;
+use tinyvec::*;
 
 #[test]
 fn TinyVec_swap_remove() {
@@ -324,29 +324,26 @@ fn TinyVec_move_to_heap_and_shrink() {
 #[test]
 fn TinyVec_ser_de_empty() {
   let tv: TinyVec<[i32; 0]> = tiny_vec![];
-  
-  assert_tokens(&tv, &[
-    Token::Seq { len: Some(0) },
 
-    Token::SeqEnd,
-]);
+  assert_tokens(&tv, &[Token::Seq { len: Some(0) }, Token::SeqEnd]);
 }
 
 #[cfg(feature = "serde")]
 #[test]
 fn TinyVec_ser_de() {
   let tv: TinyVec<[i32; 4]> = tiny_vec![1, 2, 3, 4];
-  
-  assert_tokens(&tv, &[
-    Token::Seq { len: Some(4) },
 
-    Token::I32(1),
-    Token::I32(2),
-    Token::I32(3),
-    Token::I32(4),
-
-    Token::SeqEnd,
-]);
+  assert_tokens(
+    &tv,
+    &[
+      Token::Seq { len: Some(4) },
+      Token::I32(1),
+      Token::I32(2),
+      Token::I32(3),
+      Token::I32(4),
+      Token::SeqEnd,
+    ],
+  );
 }
 
 #[cfg(feature = "serde")]
@@ -354,15 +351,16 @@ fn TinyVec_ser_de() {
 fn TinyVec_ser_de_heap() {
   let mut tv: TinyVec<[i32; 4]> = tiny_vec![1, 2, 3, 4];
   tv.move_to_the_heap();
-  
-  assert_tokens(&tv, &[
-    Token::Seq { len: Some(4) },
 
-    Token::I32(1),
-    Token::I32(2),
-    Token::I32(3),
-    Token::I32(4),
-
-    Token::SeqEnd,
-]);
+  assert_tokens(
+    &tv,
+    &[
+      Token::Seq { len: Some(4) },
+      Token::I32(1),
+      Token::I32(2),
+      Token::I32(3),
+      Token::I32(4),
+      Token::SeqEnd,
+    ],
+  );
 }

--- a/tests/tinyvec.rs
+++ b/tests/tinyvec.rs
@@ -4,6 +4,8 @@
 
 use std::iter::FromIterator;
 use tinyvec::*;
+#[cfg(feature = "serde")]
+use serde_test::{assert_tokens, Token};
 
 #[test]
 fn TinyVec_swap_remove() {
@@ -316,4 +318,51 @@ fn TinyVec_move_to_heap_and_shrink() {
   tv.extend(2..=4);
   assert_eq!(tv.capacity(), 4);
   assert_eq!(tv.as_slice(), [1, 2, 3, 4]);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn TinyVec_ser_de_empty() {
+  let tv: TinyVec<[i32; 0]> = tiny_vec![];
+  
+  assert_tokens(&tv, &[
+    Token::Seq { len: Some(0) },
+
+    Token::SeqEnd,
+]);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn TinyVec_ser_de() {
+  let tv: TinyVec<[i32; 4]> = tiny_vec![1, 2, 3, 4];
+  
+  assert_tokens(&tv, &[
+    Token::Seq { len: Some(4) },
+
+    Token::I32(1),
+    Token::I32(2),
+    Token::I32(3),
+    Token::I32(4),
+
+    Token::SeqEnd,
+]);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn TinyVec_ser_de_heap() {
+  let mut tv: TinyVec<[i32; 4]> = tiny_vec![1, 2, 3, 4];
+  tv.move_to_the_heap();
+  
+  assert_tokens(&tv, &[
+    Token::Seq { len: Some(4) },
+
+    Token::I32(1),
+    Token::I32(2),
+    Token::I32(3),
+    Token::I32(4),
+
+    Token::SeqEnd,
+]);
 }


### PR DESCRIPTION
Closes https://github.com/Lokathor/tinyvec/issues/109

Provides a [Serialize ](https://docs.serde.rs/serde/trait.Serialize.html)and [Deserialize](https://docs.serde.rs/serde/trait.Deserialize.html) implementation for both `ArrayVec` and `TinyVec`, provided that `A::Item` also implements it.

Also adds tests for serialization/deserialization.