### PR TITLE
Replace `A: Default` bounds by a constructor on `Array`

### DIFF
--- a/gen-array-impls.sh
+++ b/gen-array-impls.sh
@@ -45,8 +45,9 @@ cat <<-END
 
 	use super::Array;
 
-	$(for ((i = 0; i < 32; i++)); do gen_impl $i; done)
-	$(for ((i = 32; i <= 4096; i *= 2)); do gen_impl $i; done)
+	$(for ((i = 0; i <= 33; i++)); do gen_impl $i; done)
+
+	$(for ((i = 64; i <= 4096; i *= 2)); do gen_impl $i; done)
 END
 
 # vim: noet

--- a/gen-array-impls.sh
+++ b/gen-array-impls.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+gen_impl() {
+	local len=$1
+	cat <<-END
+		impl<T: Default> Array for [T; $len] {
+		  type Item = T;
+		  const CAPACITY: usize = $len;
+
+		  #[inline(always)]
+		  #[must_use]
+		  fn as_slice(&self) -> &[T] {
+		    &*self
+		  }
+
+		  #[inline(always)]
+		  #[must_use]
+		  fn as_slice_mut(&mut self) -> &mut [T] {
+		    &mut *self
+		  }
+
+		  #[inline(always)]
+		  fn default() -> Self {
+		    [
+		$(for ((i = 0; i < $len; i += 6))
+		do
+			echo -n '     '
+			for ((j = 0; j < 6 && j + i < $len; j++))
+			do
+				echo -n ' T::default(),'
+			done
+			echo
+		done)
+		    ]
+		  }
+		}
+
+		END
+}
+
+cat <<-END
+	// Generated file, to regenerate run
+	//     ./gen-array-impls.sh > src/array/generated_impl.rs
+	// from the repo root
+
+	use super::Array;
+
+	$(for ((i = 0; i < 32; i++)); do gen_impl $i; done)
+	$(for ((i = 32; i <= 4096; i *= 2)); do gen_impl $i; done)
+END
+
+# vim: noet

--- a/src/array.rs
+++ b/src/array.rs
@@ -34,49 +34,14 @@ pub trait Array {
   /// A correct implementation will return a slice with a length equal to the
   /// `CAPACITY` value.
   fn as_slice_mut(&mut self) -> &mut [Self::Item];
+
+  /// Create a default-initialized instance of ourself, similar to the [`Default`] trait, but
+  /// implemented for the same range of sizes as [`Array`].
+  fn default() -> Self;
 }
 
 #[cfg(feature = "nightly_const_generics")]
-impl<T: Default, const N: usize> Array for [T; N] {
-  type Item = T;
-  const CAPACITY: usize = N;
-  #[inline(always)]
-  #[must_use]
-  fn as_slice(&self) -> &[T] {
-    &*self
-  }
-  #[inline(always)]
-  #[must_use]
-  fn as_slice_mut(&mut self) -> &mut [T] {
-    &mut *self
-  }
-}
+mod const_generic_impl;
 
 #[cfg(not(feature = "nightly_const_generics"))]
-macro_rules! impl_array_for_len {
-  ($($len:expr),+ $(,)?) => {
-    $(impl<T: Default> Array for [T; $len] {
-      type Item = T;
-      const CAPACITY: usize = $len;
-      #[inline(always)]
-      #[must_use]
-      fn as_slice(&self) -> &[T] {
-        &*self
-      }
-      #[inline(always)]
-      #[must_use]
-      fn as_slice_mut(&mut self) -> &mut [T] {
-        &mut *self
-      }
-    })+
-  }
-}
-
-#[cfg(not(feature = "nightly_const_generics"))]
-impl_array_for_len! {
-  0, /* The oft-forgotten 0-length array! */
-  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
-  17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
-  33, /* for luck */
-  64, 128, 256, 512, 1024, 2048, 4096,
-}
+mod generated_impl;

--- a/src/array/const_generic_impl.rs
+++ b/src/array/const_generic_impl.rs
@@ -1,6 +1,6 @@
 use super::Array;
 
-impl<T: Default, const N: usize> Array for [T; N] where [T; N]: Default {
+impl<T: Default, const N: usize> Array for [T; N] {
   type Item = T;
   const CAPACITY: usize = N;
 
@@ -18,6 +18,6 @@ impl<T: Default, const N: usize> Array for [T; N] where [T; N]: Default {
 
   #[inline(always)]
   fn default() -> Self {
-    Default::default()
+    [(); N].map(|_| Default::default())
   }
 }

--- a/src/array/const_generic_impl.rs
+++ b/src/array/const_generic_impl.rs
@@ -1,0 +1,23 @@
+use super::Array;
+
+impl<T: Default, const N: usize> Array for [T; N] where [T; N]: Default {
+  type Item = T;
+  const CAPACITY: usize = N;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    Default::default()
+  }
+}

--- a/src/array/generated_impl.rs
+++ b/src/array/generated_impl.rs
@@ -836,6 +836,7 @@ impl<T: Default> Array for [T; 31] {
     ]
   }
 }
+
 impl<T: Default> Array for [T; 32] {
   type Item = T;
   const CAPACITY: usize = 32;
@@ -861,6 +862,35 @@ impl<T: Default> Array for [T; 32] {
       T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
       T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
       T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 33] {
+  type Item = T;
+  const CAPACITY: usize = 33;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(),
     ]
   }
 }

--- a/src/array/generated_impl.rs
+++ b/src/array/generated_impl.rs
@@ -1,0 +1,2385 @@
+// Generated file, to regenerate run
+//     ./gen-array-impls.sh > src/array/generated_impl.rs
+// from the repo root
+
+use super::Array;
+
+impl<T: Default> Array for [T; 0] {
+  type Item = T;
+  const CAPACITY: usize = 0;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 1] {
+  type Item = T;
+  const CAPACITY: usize = 1;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 2] {
+  type Item = T;
+  const CAPACITY: usize = 2;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 3] {
+  type Item = T;
+  const CAPACITY: usize = 3;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 4] {
+  type Item = T;
+  const CAPACITY: usize = 4;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 5] {
+  type Item = T;
+  const CAPACITY: usize = 5;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 6] {
+  type Item = T;
+  const CAPACITY: usize = 6;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 7] {
+  type Item = T;
+  const CAPACITY: usize = 7;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 8] {
+  type Item = T;
+  const CAPACITY: usize = 8;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 9] {
+  type Item = T;
+  const CAPACITY: usize = 9;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 10] {
+  type Item = T;
+  const CAPACITY: usize = 10;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 11] {
+  type Item = T;
+  const CAPACITY: usize = 11;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 12] {
+  type Item = T;
+  const CAPACITY: usize = 12;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 13] {
+  type Item = T;
+  const CAPACITY: usize = 13;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 14] {
+  type Item = T;
+  const CAPACITY: usize = 14;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 15] {
+  type Item = T;
+  const CAPACITY: usize = 15;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 16] {
+  type Item = T;
+  const CAPACITY: usize = 16;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 17] {
+  type Item = T;
+  const CAPACITY: usize = 17;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 18] {
+  type Item = T;
+  const CAPACITY: usize = 18;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 19] {
+  type Item = T;
+  const CAPACITY: usize = 19;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 20] {
+  type Item = T;
+  const CAPACITY: usize = 20;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 21] {
+  type Item = T;
+  const CAPACITY: usize = 21;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 22] {
+  type Item = T;
+  const CAPACITY: usize = 22;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 23] {
+  type Item = T;
+  const CAPACITY: usize = 23;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 24] {
+  type Item = T;
+  const CAPACITY: usize = 24;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 25] {
+  type Item = T;
+  const CAPACITY: usize = 25;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 26] {
+  type Item = T;
+  const CAPACITY: usize = 26;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 27] {
+  type Item = T;
+  const CAPACITY: usize = 27;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 28] {
+  type Item = T;
+  const CAPACITY: usize = 28;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 29] {
+  type Item = T;
+  const CAPACITY: usize = 29;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 30] {
+  type Item = T;
+  const CAPACITY: usize = 30;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 31] {
+  type Item = T;
+  const CAPACITY: usize = 31;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(),
+    ]
+  }
+}
+impl<T: Default> Array for [T; 32] {
+  type Item = T;
+  const CAPACITY: usize = 32;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 64] {
+  type Item = T;
+  const CAPACITY: usize = 64;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 128] {
+  type Item = T;
+  const CAPACITY: usize = 128;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 256] {
+  type Item = T;
+  const CAPACITY: usize = 256;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 512] {
+  type Item = T;
+  const CAPACITY: usize = 512;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 1024] {
+  type Item = T;
+  const CAPACITY: usize = 1024;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 2048] {
+  type Item = T;
+  const CAPACITY: usize = 2048;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(),
+    ]
+  }
+}
+
+impl<T: Default> Array for [T; 4096] {
+  type Item = T;
+  const CAPACITY: usize = 4096;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    [
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(), T::default(), T::default(),
+      T::default(), T::default(), T::default(), T::default(),
+    ]
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
   feature = "nightly_slice_partition_dedup",
   feature(slice_partition_dedup)
 )]
-#![cfg_attr(feature = "nightly_const_generics", feature(min_const_generics))]
+#![cfg_attr(feature = "nightly_const_generics", feature(min_const_generics, array_map))]
 #![cfg_attr(docs_rs, feature(doc_cfg))]
 #![warn(clippy::missing_inline_in_public_items)]
 #![warn(clippy::must_use_candidate)]

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -17,9 +17,6 @@ use serde::ser::{Serialize, SerializeSeq, Serializer};
 /// You specify the backing array type, and optionally give all the elements you
 /// want to initially place into the array.
 ///
-/// As an unfortunate restriction, the backing array type must support `Default`
-/// for it to work with this macro.
-///
 /// ```rust
 /// use tinyvec::*;
 ///
@@ -98,7 +95,8 @@ pub enum TinyVec<A: Array> {
   #[allow(missing_docs)]
   Heap(Vec<A::Item>),
 }
-impl<A: Array + Default> Default for TinyVec<A> {
+
+impl<A: Array> Default for TinyVec<A> {
   #[inline]
   #[must_use]
   fn default() -> Self {
@@ -164,7 +162,6 @@ where
 #[cfg(feature = "serde")]
 impl<'de, A: Array> Deserialize<'de> for TinyVec<A>
 where
-  A: Default,
   A::Item: Deserialize<'de>,
 {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -203,10 +200,7 @@ impl<A: Array> TinyVec<A> {
   /// tv.shrink_to_fit();
   /// assert!(tv.is_inline());
   /// ```
-  pub fn shrink_to_fit(&mut self)
-  where
-    A: Default,
-  {
+  pub fn shrink_to_fit(&mut self) {
     let vec = match self {
       TinyVec::Inline(_) => return,
       TinyVec::Heap(h) => h,
@@ -336,10 +330,7 @@ impl<A: Array> TinyVec<A> {
   /// ```
   #[inline]
   #[must_use]
-  pub fn with_capacity(cap: usize) -> Self
-  where
-    A: Default,
-  {
+  pub fn with_capacity(cap: usize) -> Self {
     if cap <= A::CAPACITY {
       TinyVec::Inline(ArrayVec::default())
     } else {
@@ -668,10 +659,7 @@ impl<A: Array> TinyVec<A> {
   /// Makes a new, empty vec.
   #[inline(always)]
   #[must_use]
-  pub fn new() -> Self
-  where
-    A: Default,
-  {
+  pub fn new() -> Self {
     Self::default()
   }
 
@@ -778,10 +766,7 @@ impl<A: Array> TinyVec<A> {
   /// assert_eq!(tv2.as_slice(), &[2, 3][..]);
   /// ```
   #[inline]
-  pub fn split_off(&mut self, at: usize) -> Self
-  where
-    A: Default,
-  {
+  pub fn split_off(&mut self, at: usize) -> Self {
     match self {
       TinyVec::Inline(a) => TinyVec::Inline(a.split_off(at)),
       TinyVec::Heap(v) => TinyVec::Heap(v.split_off(at)),
@@ -1104,7 +1089,7 @@ impl<A: Array> From<A> for TinyVec<A> {
 impl<T, A> From<&'_ [T]> for TinyVec<A>
 where
   T: Clone + Default,
-  A: Array<Item = T> + Default,
+  A: Array<Item = T>,
 {
   #[inline]
   #[must_use]
@@ -1123,7 +1108,7 @@ where
 impl<T, A> From<&'_ mut [T]> for TinyVec<A>
 where
   T: Clone + Default,
-  A: Array<Item = T> + Default,
+  A: Array<Item = T>,
 {
   #[inline]
   #[must_use]
@@ -1132,7 +1117,7 @@ where
   }
 }
 
-impl<A: Array + Default> FromIterator<A::Item> for TinyVec<A> {
+impl<A: Array> FromIterator<A::Item> for TinyVec<A> {
   #[inline]
   #[must_use]
   fn from_iter<T: IntoIterator<Item = A::Item>>(iter: T) -> Self {
@@ -1457,7 +1442,6 @@ struct TinyVecVisitor<A: Array>(PhantomData<A>);
 #[cfg(feature = "serde")]
 impl<'de, A: Array> Visitor<'de> for TinyVecVisitor<A>
 where
-  A: Default,
   A::Item: Deserialize<'de>,
 {
   type Value = TinyVec<A>;


### PR DESCRIPTION
closes #111 

This means that we now have `ArrayVec<A>: Default` for all possible `A`'s, unlocking a bunch of APIs for types like `ArrayVec<[u64; 1024]>` that were previously failing the `[u64; 1024]: Default` bound.