### PR TITLE
Implement `[value; N]` syntax support for `array_vec!`

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -36,10 +36,13 @@ macro_rules! array_vec {
     }
   };
   ($array_type:ty) => {
-    $crate::array_vec!($array_type =>)
+    $crate::ArrayVec::<$array_type>::default()
   };
   ($($elem:expr),*) => {
     $crate::array_vec!(_ => $($elem),*)
+  };
+  ($elem:expr; $n:expr) => {
+    $crate::ArrayVec::from([$elem; $n])
   };
   () => {
     $crate::array_vec!(_)

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -50,10 +50,13 @@ macro_rules! tiny_vec {
     }
   };
   ($array_type:ty) => {
-    $crate::tiny_vec!($array_type =>)
+    $crate::TinyVec::<$array_type>::default()
   };
   ($($elem:expr),*) => {
     $crate::tiny_vec!(_ => $($elem),*)
+  };
+  ($elem:expr; $n:expr) => {
+    $crate::TinyVec::from([$elem; $n])
   };
   () => {
     $crate::tiny_vec!(_)

--- a/tests/arrayvec.rs
+++ b/tests/arrayvec.rs
@@ -15,6 +15,15 @@ fn test_a_vec() {
   let actual = array_vec!(1, 2, 3);
 
   assert_eq!(expected, actual);
+
+  assert_eq!(array_vec![0u8; 4], array_vec!(0u8, 0u8, 0u8, 0u8));
+  assert_eq!(array_vec![0u8; 4], array_vec!([u8; 4] => 0, 0, 0, 0));
+  assert_eq!(array_vec![0; 4], array_vec!(0, 0, 0, 0));
+  assert_eq!(array_vec![0; 4], array_vec!([u8; 4] => 0, 0, 0, 0));
+
+  let expected2 = array_vec![1.1; 3];
+  let actual2 = array_vec!([f32; 3] => 1.1, 1.1, 1.1);
+  assert_eq!(expected2, actual2);
 }
 
 #[test]

--- a/tests/tinyvec.rs
+++ b/tests/tinyvec.rs
@@ -262,6 +262,27 @@ fn TinyVec_from_array() {
 }
 
 #[test]
+fn TinyVec_macro() {
+  let mut expected: TinyVec<[i32; 4]> = Default::default();
+  expected.push(1);
+  expected.push(2);
+  expected.push(3);
+
+  let actual = tiny_vec!(1, 2, 3);
+
+  assert_eq!(expected, actual);
+
+  assert_eq!(tiny_vec![0u8; 4], tiny_vec!(0u8, 0u8, 0u8, 0u8));
+  assert_eq!(tiny_vec![0u8; 4], tiny_vec!([u8; 4] => 0, 0, 0, 0));
+  assert_eq!(tiny_vec![0; 4], tiny_vec!(0, 0, 0, 0));
+  assert_eq!(tiny_vec![0; 4], tiny_vec!([u8; 4] => 0, 0, 0, 0));
+
+  let expected2 = tiny_vec![1.1; 3];
+  let actual2 = tiny_vec!([f32; 3] => 1.1, 1.1, 1.1);
+  assert_eq!(expected2, actual2);
+}
+
+#[test]
 fn TinyVec_macro_non_copy() {
   // must use a variable here to avoid macro shenanigans
   let s = String::new();


### PR DESCRIPTION
Closes #117. I also improved one of the other variants of the macro a little bit while I was at it.