### PR TITLE
Implement remove with swap instead of rotate_left

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -601,7 +601,9 @@ impl<A: Array> ArrayVec<A> {
   pub fn remove(&mut self, index: usize) -> A::Item {
     let targets: &mut [A::Item] = &mut self.deref_mut()[index..];
     let item = take(&mut targets[0]);
-    targets.rotate_left(1);
+    for i in 0..targets.len() - 1 {
+      targets.swap(i, i + 1);
+    }
     self.len -= 1;
     item
   }


### PR DESCRIPTION
The codegen from `slice::rotate_left` is pretty ghastly; in my compiled benchmarks it's some 272 instructions with a number calls to `memcpy` and `memmove`, but only a few instructions are actually hot when it's run, and of course it isn't inlined (because it's huge?).

I think this implementation brings `TinyVec::remove` to parity with or possibly faster than `SmallVec::remove`.