### PR TITLE
use alternate printing when requested.

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1,5 +1,5 @@
 use super::*;
-use core::convert::{TryInto, TryFrom};
+use core::convert::{TryFrom, TryInto};
 
 #[cfg(feature = "serde")]
 use core::marker::PhantomData;
@@ -1190,20 +1190,22 @@ impl<A: Array> From<A> for ArrayVec<A> {
   }
 }
 
-/// The error type returned when a conversion from a slice to an [`ArrayVec`] fails.
+/// The error type returned when a conversion from a slice to an [`ArrayVec`]
+/// fails.
 #[derive(Debug, Copy, Clone)]
 pub struct TryFromSliceError(());
 
 impl<T, A> TryFrom<&'_ [T]> for ArrayVec<A>
 where
-    T: Clone + Default,
-    A: Array<Item = T>,
+  T: Clone + Default,
+  A: Array<Item = T>,
 {
   type Error = TryFromSliceError;
 
   #[inline]
   #[must_use]
-  /// The output has a length equal to that of the slice, with the same capacity as `A`.
+  /// The output has a length equal to that of the slice, with the same capacity
+  /// as `A`.
   fn try_from(slice: &[T]) -> Result<Self, Self::Error> {
     if slice.len() > A::CAPACITY {
       Err(TryFromSliceError(()))
@@ -1453,11 +1455,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Binary::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1469,7 +1477,20 @@ where
 {
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-    core::fmt::Debug::fmt(self.as_slice(), f)
+    write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
+    for (i, elem) in self.iter().enumerate() {
+      if i > 0 {
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
+      }
+      Debug::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
+    }
+    write!(f, "]")
   }
 }
 
@@ -1480,11 +1501,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Display::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1497,11 +1524,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       LowerExp::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1514,11 +1547,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       LowerHex::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1531,11 +1570,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Octal::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1548,11 +1593,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Pointer::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1565,11 +1616,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       UpperExp::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1582,11 +1639,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       UpperHex::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }

--- a/src/slicevec.rs
+++ b/src/slicevec.rs
@@ -879,11 +879,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Binary::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -896,11 +902,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Debug::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -913,11 +925,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Display::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -930,11 +948,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       LowerExp::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -947,11 +971,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       LowerHex::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -964,11 +994,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Octal::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -981,11 +1017,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Pointer::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -998,11 +1040,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       UpperExp::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1015,11 +1063,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       UpperHex::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -1309,11 +1309,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Binary::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1325,7 +1331,20 @@ where
 {
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-    core::fmt::Debug::fmt(self.as_slice(), f)
+    write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
+    for (i, elem) in self.iter().enumerate() {
+      if i > 0 {
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
+      }
+      Debug::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
+    }
+    write!(f, "]")
   }
 }
 
@@ -1336,11 +1355,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Display::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1353,11 +1378,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       LowerExp::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1370,11 +1401,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       LowerHex::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1387,11 +1424,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Octal::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1404,11 +1447,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       Pointer::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1421,11 +1470,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       UpperExp::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }
@@ -1438,11 +1493,17 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
+    if f.alternate() {
+      write!(f, "\n    ")?;
+    }
     for (i, elem) in self.iter().enumerate() {
       if i > 0 {
-        write!(f, ", ")?;
+        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
       }
       UpperHex::fmt(elem, f)?;
+    }
+    if f.alternate() {
+      write!(f, ",\n")?;
     }
     write!(f, "]")
   }


### PR DESCRIPTION
Brings the https://github.com/Lokathor/tinyvec/pull/138 to all fmt styles on all three vec types we've got.