### PR TITLE
Add to `ArrayVec` a `from_array_empty` Constructor  as `const fn`

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -96,10 +96,13 @@ macro_rules! array_vec {
 ///
 /// let more_ints = ArrayVec::from_array_len([5, 6, 7, 8], 2);
 /// assert_eq!(more_ints.len(), 2);
+///
+/// let no_ints: ArrayVec<[u8; 5]> = ArrayVec::from_array_empty([1, 2, 3, 4, 5]);
+/// assert_eq!(no_ints.len(), 0);
 /// ```
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct ArrayVec<A: Array> {
+pub struct ArrayVec<A> {
   len: u16,
   pub(crate) data: A,
 }
@@ -951,6 +954,37 @@ impl<A: Array> ArrayVec<A> {
     } else {
       Err(data)
     }
+  }
+}
+
+impl<A> ArrayVec<A> {
+  /// Wraps up an array as a new empty `ArrayVec`.
+  ///
+  /// If you want to simply use the full array, use `from` instead.
+  ///
+  /// ## Examples
+  ///
+  /// This method in particular allows to create values for statics:
+  ///
+  /// ```rust
+  /// # use tinyvec::ArrayVec;
+  /// static DATA: ArrayVec<[u8; 5]> = ArrayVec::from_array_empty([0; 5]);
+  /// assert_eq!(DATA.len(), 0);
+  /// ```
+  ///
+  /// But of course it is just an normal empty `ArrayVec`:
+  ///
+  /// ```rust
+  /// # use tinyvec::ArrayVec;
+  /// let mut data = ArrayVec::from_array_empty([1, 2, 3, 4]);
+  /// assert_eq!(&data[..], &[]);
+  /// data.push(42);
+  /// assert_eq!(&data[..], &[42]);
+  /// ```
+  #[inline]
+  #[must_use]
+  pub const fn from_array_empty(data: A) -> Self {
+    Self { data, len: 0 }
   }
 }
 


### PR DESCRIPTION
This PR adds a new constructor `from_array_empty` to the `ArrayVec`, which takes an `Array` by value and uses it only as storage space, thus initializing with zero length (i.e. empty). Since this is generally valid unlike the `from_array_len` (which requires an additional check), this check-free version now is eligible to become a `const fn` to allow `ArrayVec` even in `static` context.

However, since `const fn`s may not have any trait bounds (as of Rust 1.51), the `A: Array` trait bound on the `ArrayVec` struct itself, is lifted, apparently, it was never used tho.

Since this PR only adds a new function and lifts a constraint, this change should be perfectly backwards compatible.