### PR TITLE
Add arbitrary implementations for TinyVec and ArrayVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ repository = "https://github.com/Lokathor/tinyvec"
 tinyvec_macros = { version = "0.1", optional = true }
 # Provides `Serialize` and `Deserialize` implementations
 serde = { version = "1.0", optional = true, default-features = false }
+# Provides derived `Arbitrary` implementations
+arbitrary = { version = "1", optional = true }
 
 [features]
 default = []

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -180,6 +180,22 @@ where
   }
 }
 
+#[cfg(all(feature = "arbitrary", feature = "nightly_const_generics"))]
+#[cfg_attr(
+  docs_rs,
+  doc(cfg(all(feature = "arbitrary", feature = "nightly_const_generics")))
+)]
+impl<'a, T, const N: usize> arbitrary::Arbitrary<'a> for ArrayVec<[T; N]>
+where
+  T: arbitrary::Arbitrary<'a> + Default,
+{
+  fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+    let v = <[T; N]>::arbitrary(u)?;
+    let av = ArrayVec::from(v);
+    Ok(av)
+  }
+}
+
 impl<A: Array> ArrayVec<A> {
   /// Move all values from `other` into this vec.
   ///

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -178,6 +178,21 @@ where
   }
 }
 
+#[cfg(feature = "arbitrary")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "arbitrary")))]
+impl<'a, A> arbitrary::Arbitrary<'a> for TinyVec<A>
+where
+  A: Array,
+  A::Item: arbitrary::Arbitrary<'a>,
+{
+  fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+    let v = Vec::arbitrary(u)?;
+    let mut tv = TinyVec::Heap(v);
+    tv.shrink_to_fit();
+    Ok(tv)
+  }
+}
+
 impl<A: Array> TinyVec<A> {
   /// Returns whether elements are on heap
   #[inline(always)]


### PR DESCRIPTION
This makes it easier to use these in fuzzing some structures that use these types without having to use newtype structs everywhere.