### PR TITLE
Rename nightly_const_generics to rustc_1_55 and remove feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,14 @@ grab_spare_slice = []
 # DoubleEndedIterator::nth_back - 1.40
 rustc_1_40 = []
 
+# features that require rustc 1.55
+# use const generics to implement Array for all array lengths
+rustc_1_55 = []
+
 # allow use of nightly feature `slice_partition_dedup`,
 # will become useless once that is stabilized:
 # https://github.com/rust-lang/rust/issues/54279
 nightly_slice_partition_dedup = []
-
-# use const generics for arrays
-nightly_const_generics = []
 
 # EXPERIMENTAL: Not part of SemVer. It adds `core::fmt::Write` to `ArrayVec`
 # and `SliceVec`. It works on Stable Rust, but Vec normally supports the
@@ -46,11 +47,11 @@ nightly_const_generics = []
 experimental_write_impl = []
 
 [package.metadata.docs.rs]
-features = ["alloc", "grab_spare_slice", "rustc_1_40", "serde"]
+features = ["alloc", "grab_spare_slice", "rustc_1_40", "rustc_1_55", "serde"]
 rustdoc-args = ["--cfg","docs_rs"]
 
 [package.metadata.playground]
-features = ["alloc", "grab_spare_slice", "rustc_1_40", "serde"]
+features = ["alloc", "grab_spare_slice", "rustc_1_40", "rustc_1_55", "serde"]
 
 [profile.test]
 opt-level = 3

--- a/src/array.rs
+++ b/src/array.rs
@@ -8,7 +8,7 @@
 ///
 /// You are generally **not** expected to need to implement this yourself. It is
 /// already implemented for all the major array lengths (`0..=32` and the powers
-/// of 2 up to 4,096).
+/// of 2 up to 4,096), or for all array lengths with the feature `rustc_1_55`.
 ///
 /// **Additional lengths can easily be added upon request.**
 ///
@@ -41,8 +41,8 @@ pub trait Array {
   fn default() -> Self;
 }
 
-#[cfg(feature = "nightly_const_generics")]
+#[cfg(feature = "rustc_1_55")]
 mod const_generic_impl;
 
-#[cfg(not(feature = "nightly_const_generics"))]
+#[cfg(not(feature = "rustc_1_55"))]
 mod generated_impl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,6 @@
   feature = "nightly_slice_partition_dedup",
   feature(slice_partition_dedup)
 )]
-#![cfg_attr(
-  feature = "nightly_const_generics",
-  feature(min_const_generics, array_map)
-)]
 #![cfg_attr(docs_rs, feature(doc_cfg))]
 #![warn(clippy::missing_inline_in_public_items)]
 #![warn(clippy::must_use_candidate)]


### PR DESCRIPTION
All the requirements for the `nightly_const_generics` features are stable, so it seems appropriate to be able to use this feature on a stable toolchain, and without a name that suggests the feature requires nightly.