### PR TITLE
Fix building on Rust 1.34 with `alloc` feature enabled

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         rust:
         - 1.34.0
+        - 1.36.0
         - stable
         - beta
         - nightly
@@ -25,13 +26,15 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-    - name: Build the crate on minimal version w. features.
+    - name: Build the crate on 1.36 with features.
+      if: matrix.rust != '1.34.0'
       uses: actions-rs/cargo@v1
       with:
         command: build
+        # Using `extern crate alloc` is only possible after 1.36
         args: --features=alloc,std,grab_spare_slice
     - name: Test on Stable/Beta
-      if: matrix.rust != '1.34.0'
+      if: matrix.rust != '1.34.0' && matrix.rust != '1.36.0'
       uses: actions-rs/cargo@v1
       with:
         command: test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,11 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
+    - name: Build the crate on minimal version w. features.
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --features=alloc,std,grab_spare_slice
     - name: Test on Stable/Beta
       if: matrix.rust != '1.34.0'
       uses: actions-rs/cargo@v1

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -107,8 +107,8 @@ where
   #[inline]
   fn clone(&self) -> Self {
     match self {
-      Self::Heap(v) => Self::Heap(v.clone()),
-      Self::Inline(v) => Self::Inline(v.clone()),
+      TinyVec::Heap(v) => TinyVec::Heap(v.clone()),
+      TinyVec::Inline(v) => TinyVec::Inline(v.clone()),
     }
   }
 


### PR DESCRIPTION
The MSRV was violated in 13008731ba7aaf446d0f1ec55dee8c41ced1654f when the `alloc` feature is enabled. This PR fixes that.

[`url`](https://github.com/servo/rust-url)'s CI currently fails because of this, see for example [this](https://github.com/servo/rust-url/runs/4150073227?check_suite_focus=true).