### PR TITLE
add `try_` functions for fallible heap growth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ rustc_1_40 = []
 # use const generics to implement Array for all array lengths
 rustc_1_55 = ["rustc_1_40"]
 
+# features that require rustc 1.57
+# add try_reserve functions to types that heap allocate.
+rustc_1_57 = ["rustc_1_55"]
+
 # allow use of nightly feature `slice_partition_dedup`,
 # will become useless once that is stabilized:
 # https://github.com/rust-lang/rust/issues/54279

--- a/tests/tinyvec.rs
+++ b/tests/tinyvec.rs
@@ -304,6 +304,22 @@ fn TinyVec_reserve() {
   assert!(tv.capacity() >= 10);
 }
 
+#[cfg(feature = "rustc_1_57")]
+#[test]
+fn TinyVec_try_reserve() {
+  let mut tv: TinyVec<[i32; 4]> = Default::default();
+  assert_eq!(tv.capacity(), 4);
+  tv.extend_from_slice(&[1, 2]);
+  assert_eq!(tv.capacity(), 4);
+  assert!(tv.try_reserve(2).is_ok());
+  assert_eq!(tv.capacity(), 4);
+  assert!(tv.try_reserve(4).is_ok());
+  assert!(tv.capacity() >= 6);
+  tv.extend_from_slice(&[3, 4, 5, 6]);
+  assert!(tv.try_reserve(4).is_ok());
+  assert!(tv.capacity() >= 10);
+}
+
 #[test]
 fn TinyVec_reserve_exact() {
   let mut tv: TinyVec<[i32; 4]> = Default::default();
@@ -317,6 +333,23 @@ fn TinyVec_reserve_exact() {
   assert!(tv.capacity() >= 6);
   tv.extend_from_slice(&[3, 4, 5, 6]);
   tv.reserve_exact(4);
+  assert!(tv.capacity() >= 10);
+}
+
+#[cfg(feature = "rustc_1_57")]
+#[test]
+fn TinyVec_try_reserve_exact() {
+  let mut tv: TinyVec<[i32; 4]> = Default::default();
+  assert_eq!(tv.capacity(), 4);
+
+  tv.extend_from_slice(&[1, 2]);
+  assert_eq!(tv.capacity(), 4);
+  assert!(tv.try_reserve_exact(2).is_ok());
+  assert_eq!(tv.capacity(), 4);
+  assert!(tv.try_reserve_exact(4).is_ok());
+  assert!(tv.capacity() >= 6);
+  tv.extend_from_slice(&[3, 4, 5, 6]);
+  assert!(tv.try_reserve_exact(4).is_ok());
   assert!(tv.capacity() >= 10);
 }
 
@@ -334,6 +367,30 @@ fn TinyVec_move_to_heap_and_shrink() {
   assert_eq!(tv.capacity(), 4);
 
   tv.move_to_the_heap_and_reserve(3);
+  assert!(tv.is_heap());
+  assert_eq!(tv.capacity(), 4);
+  tv.extend(2..=4);
+  assert_eq!(tv.capacity(), 4);
+  assert_eq!(tv.as_slice(), [1, 2, 3, 4]);
+}
+
+#[cfg(feature = "rustc_1_57")]
+#[test]
+fn TinyVec_try_move_to_heap_and_shrink() {
+  let mut tv: TinyVec<[i32; 4]> = Default::default();
+  assert!(tv.is_inline());
+  assert!(tv.try_move_to_the_heap().is_ok());
+  assert!(tv.is_heap());
+  assert_eq!(tv.capacity(), 0);
+
+  assert!(tv.try_reserve_exact(1).is_ok());
+  assert_eq!(tv.capacity(), 1);
+  tv.push(1);
+  tv.shrink_to_fit();
+  assert!(tv.is_inline());
+  assert_eq!(tv.capacity(), 4);
+
+  assert!(tv.try_move_to_the_heap_and_reserve(3).is_ok());
   assert!(tv.is_heap());
   assert_eq!(tv.capacity(), 4);
   tv.extend(2..=4);


### PR DESCRIPTION
Quickly whipped up something for #157. Of course there might be a function or two around the place that could use these functions. For now I just ensured the `TinyVec` and `ArrayVec` -> `Vec` functions for reserving extra space or spilling into the heap have fallible allocations.

I imagine I probably need to add to benchs, fuzzing and the tests?
