### PR TITLE
Error implementation for TryFromSliceError

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1281,6 +1281,15 @@ impl<A: Array> From<A> for ArrayVec<A> {
 #[derive(Debug, Copy, Clone)]
 pub struct TryFromSliceError(());
 
+impl core::fmt::Display for TryFromSliceError {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+    f.write_str("could not convert slice to ArrayVec")
+  }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TryFromSliceError {}
+
 impl<T, A> TryFrom<&'_ [T]> for ArrayVec<A>
 where
   T: Clone + Default,

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1271,7 +1271,7 @@ impl<A: Array> From<A> for ArrayVec<A> {
       .as_slice()
       .len()
       .try_into()
-      .expect("ArrayVec::from> lenght must be in range 0..=u16::MAX");
+      .expect("ArrayVec::from> length must be in range 0..=u16::MAX");
     Self { len, data }
   }
 }


### PR DESCRIPTION
* Implement `core::fmt::Display` for `TryFromSliceError`
* If feature `std` is enabled, implement `std::error::Error` for `TryFromSliceError`
* Fix a typo in the `expect` message of `impl<A: Array> From<A> for ArrayVec<A>`