### PR TITLE
fix `Debug` alternate mode for empty containers

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1573,7 +1573,7 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
-    if f.alternate() {
+    if f.alternate() && !self.is_empty() {
       write!(f, "\n    ")?;
     }
     for (i, elem) in self.iter().enumerate() {
@@ -1582,7 +1582,7 @@ where
       }
       Debug::fmt(elem, f)?;
     }
-    if f.alternate() {
+    if f.alternate() && !self.is_empty() {
       write!(f, ",\n")?;
     }
     write!(f, "]")

--- a/src/slicevec.rs
+++ b/src/slicevec.rs
@@ -902,7 +902,7 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
-    if f.alternate() {
+    if f.alternate() && !self.is_empty() {
       write!(f, "\n    ")?;
     }
     for (i, elem) in self.iter().enumerate() {
@@ -911,7 +911,7 @@ where
       }
       Debug::fmt(elem, f)?;
     }
-    if f.alternate() {
+    if f.alternate() && !self.is_empty() {
       write!(f, ",\n")?;
     }
     write!(f, "]")

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -1528,7 +1528,7 @@ where
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
     write!(f, "[")?;
-    if f.alternate() {
+    if f.alternate() && !self.is_empty() {
       write!(f, "\n    ")?;
     }
     for (i, elem) in self.iter().enumerate() {
@@ -1537,7 +1537,7 @@ where
       }
       Debug::fmt(elem, f)?;
     }
-    if f.alternate() {
+    if f.alternate() && !self.is_empty() {
       write!(f, ",\n")?;
     }
     write!(f, "]")


### PR DESCRIPTION
Consider the following code:
```rust
println!("{:#?}", tiny_vec!([u8; 16]));
```
I expected to see:
```
[]
```
but actually saw:
```
[
    ,
]
```