### PR TITLE
Fix debugger_visualizer.rs tests

### DIFF
--- a/tests/debugger_visualizer.rs
+++ b/tests/debugger_visualizer.rs
@@ -18,13 +18,13 @@ g
 dx strings
 "#,
     expected_statements = r#"
-strings          : { len=0x3 } [Type: tinyvec::arrayvec::ArrayVec<array$<str,7> >]
-    [<Raw View>]     [Type: tinyvec::arrayvec::ArrayVec<array$<str,7> >]
-    [len]            : 0x3 [Type: unsigned short]
-    [capacity]       : 7
-    [0]              : "a" [Type: str]
-    [1]              : "b" [Type: str]
-    [2]              : "c" [Type: str]
+pattern:strings          : \{ len=0x3 \} \[Type: tinyvec::arrayvec::ArrayVec<array$<.*str.*,7> >\]
+pattern:    \[<Raw View>\]     \[Type: tinyvec::arrayvec::ArrayVec<array$<.*str.*,7> >\]
+pattern:    \[len\]            : 0x3 \[Type: unsigned short\]
+pattern:    \[capacity\]       : 7
+pattern:    \[0\]              : "a" \[Type: .*str.*\]
+pattern:    \[1\]              : "b" \[Type: .*str.*\]
+pattern:    \[2\]              : "c" \[Type: .*str.*\]
 
 inline_tv        : Inline [Type: enum2$<tinyvec::tinyvec::TinyVec<array$<i32,4> > >]
     [<Raw View>]     [Type: enum2$<tinyvec::tinyvec::TinyVec<array$<i32,4> > >]
@@ -39,23 +39,23 @@ inline_tv.__0    : { len=0x4 } [Type: tinyvec::arrayvec::ArrayVec<array$<i32,4> 
     [2]              : 3 [Type: i32]
     [3]              : 4 [Type: i32]
 
-slice_vec        : { len=0x3 } [Type: tinyvec::slicevec::SliceVec<str>]
-    [<Raw View>]     [Type: tinyvec::slicevec::SliceVec<str>]
-    [len]            : 0x3 [Type: unsigned __int64]
-    [0]              : "a" [Type: str]
-    [1]              : "b" [Type: str]
-    [2]              : "d" [Type: str]
+pattern:slice_vec        : \{ len=0x3 \} \[Type: tinyvec::slicevec::SliceVec<.*str.*>\]
+pattern:    \[<Raw View>\]     \[Type: tinyvec::slicevec::SliceVec<.*str.*>\]
+pattern:    \[len\]            : 0x3 \[Type: unsigned __int64\]
+pattern:    \[0\]              : "a" \[Type: .*str.*\]
+pattern:    \[1\]              : "b" \[Type: .*str.*\]
+pattern:    \[2\]              : "d" \[Type: .*str.*\]
 
-strings          : { len=0x6 } [Type: tinyvec::arrayvec::ArrayVec<array$<str,7> >]
-    [<Raw View>]     [Type: tinyvec::arrayvec::ArrayVec<array$<str,7> >]
-    [len]            : 0x6 [Type: unsigned short]
-    [capacity]       : 7
-    [0]              : "a" [Type: str]
-    [1]              : "b" [Type: str]
-    [2]              : "d" [Type: str]
-    [3]              : "e" [Type: str]
-    [4]              : "f" [Type: str]
-    [5]              : "g" [Type: str]
+pattern:strings          : \{ len=0x6 \} \[Type: tinyvec::arrayvec::ArrayVec<array$<.*str.*,7> >\]
+pattern:    \[<Raw View>\]     \[Type: tinyvec::arrayvec::ArrayVec<array$<.*str.*,7> >\]
+pattern:    \[len\]            : 0x6 \[Type: unsigned short\]
+pattern:    \[capacity\]       : 7
+pattern:    \[0\]              : "a" \[Type: .*str.*\]
+pattern:    \[1\]              : "b" \[Type: .*str.*\]
+pattern:    \[2\]              : "d" \[Type: .*str.*\]
+pattern:    \[3\]              : "e" \[Type: .*str.*\]
+pattern:    \[4\]              : "f" \[Type: .*str.*\]
+pattern:    \[5\]              : "g" \[Type: .*str.*\]
 "#
 )]
 #[inline(never)]

--- a/tests/debugger_visualizer.rs
+++ b/tests/debugger_visualizer.rs
@@ -18,13 +18,13 @@ g
 dx strings
 "#,
     expected_statements = r#"
-pattern:strings          : \{ len=0x3 \} \[Type: tinyvec::arrayvec::ArrayVec<array$<.*str.*,7> >\]
-pattern:    \[<Raw View>\]     \[Type: tinyvec::arrayvec::ArrayVec<array$<.*str.*,7> >\]
-pattern:    \[len\]            : 0x3 \[Type: unsigned short\]
-pattern:    \[capacity\]       : 7
-pattern:    \[0\]              : "a" \[Type: .*str.*\]
-pattern:    \[1\]              : "b" \[Type: .*str.*\]
-pattern:    \[2\]              : "c" \[Type: .*str.*\]
+pattern:strings          : \{ len=0x3 \} \[Type: tinyvec::arrayvec::ArrayVec<array\$<.*str.*,7> >\]
+pattern:\[<Raw View>\]     \[Type: tinyvec::arrayvec::ArrayVec<array\$<.*str.*,7> >\]
+pattern:\[len\]            : 0x3 \[Type: unsigned short\]
+pattern:\[capacity\]       : 7
+pattern:\[0\]              : "a" \[Type: .*str.*\]
+pattern:\[1\]              : "b" \[Type: .*str.*\]
+pattern:\[2\]              : "c" \[Type: .*str.*\]
 
 inline_tv        : Inline [Type: enum2$<tinyvec::tinyvec::TinyVec<array$<i32,4> > >]
     [<Raw View>]     [Type: enum2$<tinyvec::tinyvec::TinyVec<array$<i32,4> > >]
@@ -40,22 +40,22 @@ inline_tv.__0    : { len=0x4 } [Type: tinyvec::arrayvec::ArrayVec<array$<i32,4> 
     [3]              : 4 [Type: i32]
 
 pattern:slice_vec        : \{ len=0x3 \} \[Type: tinyvec::slicevec::SliceVec<.*str.*>\]
-pattern:    \[<Raw View>\]     \[Type: tinyvec::slicevec::SliceVec<.*str.*>\]
-pattern:    \[len\]            : 0x3 \[Type: unsigned __int64\]
-pattern:    \[0\]              : "a" \[Type: .*str.*\]
-pattern:    \[1\]              : "b" \[Type: .*str.*\]
-pattern:    \[2\]              : "d" \[Type: .*str.*\]
+pattern:\[<Raw View>\]     \[Type: tinyvec::slicevec::SliceVec<.*str.*>\]
+pattern:\[len\]            : 0x3 \[Type: unsigned __int64\]
+pattern:\[0\]              : "a" \[Type: .*str.*\]
+pattern:\[1\]              : "b" \[Type: .*str.*\]
+pattern:\[2\]              : "d" \[Type: .*str.*\]
 
-pattern:strings          : \{ len=0x6 \} \[Type: tinyvec::arrayvec::ArrayVec<array$<.*str.*,7> >\]
-pattern:    \[<Raw View>\]     \[Type: tinyvec::arrayvec::ArrayVec<array$<.*str.*,7> >\]
-pattern:    \[len\]            : 0x6 \[Type: unsigned short\]
-pattern:    \[capacity\]       : 7
-pattern:    \[0\]              : "a" \[Type: .*str.*\]
-pattern:    \[1\]              : "b" \[Type: .*str.*\]
-pattern:    \[2\]              : "d" \[Type: .*str.*\]
-pattern:    \[3\]              : "e" \[Type: .*str.*\]
-pattern:    \[4\]              : "f" \[Type: .*str.*\]
-pattern:    \[5\]              : "g" \[Type: .*str.*\]
+pattern:strings          : \{ len=0x6 \} \[Type: tinyvec::arrayvec::ArrayVec<array\$<.*str.*,7> >\]
+pattern:\[<Raw View>\]     \[Type: tinyvec::arrayvec::ArrayVec<array\$<.*str.*,7> >\]
+pattern:\[len\]            : 0x6 \[Type: unsigned short\]
+pattern:\[capacity\]       : 7
+pattern:\[0\]              : "a" \[Type: .*str.*\]
+pattern:\[1\]              : "b" \[Type: .*str.*\]
+pattern:\[2\]              : "d" \[Type: .*str.*\]
+pattern:\[3\]              : "e" \[Type: .*str.*\]
+pattern:\[4\]              : "f" \[Type: .*str.*\]
+pattern:\[5\]              : "g" \[Type: .*str.*\]
 "#
 )]
 #[inline(never)]
@@ -65,10 +65,10 @@ fn test_debugger_visualizer() {
     strings.push("b");
     strings.push("c");
     assert_eq!(["a", "b", "c"], &strings[..]);
-    
+
     let mut inline_tv = tiny_vec!([i32; 4] => 1, 2, 3);
     assert!(inline_tv.is_inline());
-    
+
     inline_tv.push(4);
     __break();
 
@@ -82,7 +82,7 @@ fn test_debugger_visualizer() {
 
         assert_eq!(["a", "b", "d"], &slice_vec[..]);
     }
-    
+
     strings.push("e");
     strings.push("f");
     strings.push("g");


### PR DESCRIPTION
Nightly replaced a lot of `str` with `ref$<str$>`.  Took the approach of abusing wildcard `.*str.*` regexps/patterns to make this test less brittle to rustc/std specifics.

https://github.com/rust-lang/rust/commit/0cd2dd7263a20ba62591039cd3591c8eaef13878