### PR TITLE
Implement ExactSizeIterator for ArrayVecIterator and TinyVecIterator

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1420,6 +1420,13 @@ impl<A: Array> DoubleEndedIterator for ArrayVecIterator<A> {
   }
 }
 
+impl<A: Array> ExactSizeIterator for ArrayVecIterator<A> {
+  #[inline]
+  fn len(&self) -> usize {
+    self.size_hint().0
+  }
+}
+
 impl<A: Array> Debug for ArrayVecIterator<A>
 where
   A::Item: Debug,

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -1386,6 +1386,14 @@ impl<A: Array> DoubleEndedIterator for TinyVecIterator<A> {
   }
 }
 
+impl<A: Array> ExactSizeIterator for TinyVecIterator<A> {
+  impl_mirrored! {
+    type Mirror = TinyVecIterator;
+    #[inline]
+    fn len(self: &Self) -> usize;
+  }
+}
+
 impl<A: Array> Debug for TinyVecIterator<A>
 where
   A::Item: Debug,


### PR DESCRIPTION
These implementations weren't present but I'm not sure there was a reason. They seem pretty sound to me, but I'm very new to looking at this crate!

The `len` implementation of `ArrayVecIterator` is just the same as `count`.