### PR TITLE
Fix a few typos

### DIFF
--- a/debug_metadata/README.md
+++ b/debug_metadata/README.md
@@ -18,7 +18,7 @@ The GNU debugger (GDB) supports defining custom debugger views using Pretty Prin
 Pretty printers are written as python scripts that describe how a type should be displayed
 when loaded up in GDB/LLDB. (See: https://sourceware.org/gdb/onlinedocs/gdb/Pretty-Printing.html#Pretty-Printing)
 The pretty printers provide patterns, which match type names, and for matching
-types, descibe how to display those types. (For writing a pretty printer, see: https://sourceware.org/gdb/onlinedocs/gdb/Writing-a-Pretty_002dPrinter.html#Writing-a-Pretty_002dPrinter).
+types, describe how to display those types. (For writing a pretty printer, see: https://sourceware.org/gdb/onlinedocs/gdb/Writing-a-Pretty_002dPrinter.html#Writing-a-Pretty_002dPrinter).
 
 ### Embedding Visualizers
 

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -719,7 +719,7 @@ impl<A: Array> TinyVec<A> {
   /// **Note: This method has significant performance issues compared to
   /// matching on the TinyVec and then calling drain on the Inline or Heap value
   /// inside. The draining iterator has to branch on every single access. It is
-  /// provided for simplicity and compatability only.**
+  /// provided for simplicity and compatibility only.**
   ///
   /// ## Panics
   /// * If the start is greater than the end


### PR DESCRIPTION
Fix two typos in documentation.