### PR TITLE
Update actions/checkout in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflows to its newest major version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.3.0
> - Implement branch list using callbacks from exec function
> - Add in explicit reference to private checkout options
> - Fix comment typos
>
> ## v3.2.0
> - Add GitHub Action to perform release
> - Fix status badge
> - Replace datadog/squid with ubuntu/squid Docker image
> - Wrap pipeline commands for submoduleForeach in quotes
> - Update @actions/io to 1.1.2
> - Upgrading version to 3.2.0
>
> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16
>
> ## v2.3.1
> 
> - Fix default branch resolution for .wiki and when using SSH
> 
> ## v2.3.0
> 
> - Fallback to the default branch
> 
> ## v2.2.0
> 
> - Fetch all history for all tags and branches when fetch-depth=0
> 
> ## v2.1.1
> 
> - Changes to support GHES
> 
> ## v2.1.0
> 
> - Group output
> - Changes to support GHES alpha release
> - Persist core.sshCommand for submodules
> - Add support ssh
> - Convert submodule SSH URL to HTTPS, when not using SSH
> - Add submodule support
> - Follow proxy settings
> - Fix ref for pr closed event when a pr is merged
> - Fix issue checking detached when git less than 2.22
> 
> ## v2.0.0
> 
> - Do not pass cred on command line
> - Add input persist-credentials
> - Fallback to REST API to download repo


Still using v2 of `actions/checkout` will generate some warning like in this run: https://github.com/Lokathor/tinyvec/actions/runs/3653238576

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/checkout`, because v3 uses Node.js 16.