### PR TITLE
Replace unmaintained actions-rs actions in CI workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,41 +23,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
-        default: true
     - name: Build the crate on minimal version.
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
+      run: |
+        cargo build
     - name: Build the crate on 1.36 with features.
       if: matrix.rust != '1.34.0'
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
+      run: |
         # Using `extern crate alloc` is only possible after 1.36
-        args: --features=alloc,std,grab_spare_slice
+        cargo build --features=alloc,std,grab_spare_slice
     - name: Test on Stable/Beta
       if: matrix.rust != '1.34.0' && matrix.rust != '1.36.0'
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --features=alloc --features=grab_spare_slice --features=rustc_1_40
+      run: |
+        cargo test --features=alloc --features=grab_spare_slice --features=rustc_1_40
     - name: Test on Nightly with All Features
       if: matrix.rust == 'nightly'
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all-features
+      run: |
+        cargo test --all-features
     # The #[debugger_visualizer] attribute is currently gated behind an unstable feature flag.
     # In order to test the visualizers for the tinyvec crate, they have to be tested on a nightly build.
     - name: Test debugger_visualizer feature on Nightly
       if: |
         matrix.os == 'windows-latest' &&
         matrix.rust == 'nightly'
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all-features --test debugger_visualizer -- --test-threads=1
+      run: |
+        cargo test --all-features --test debugger_visualizer -- --test-threads=1


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, like for example:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1

To get rid of those warnings the `actions-rs/toolchain` is replaced by the newer `dtolnay/rust-toolchain` and occurrences of `actions-rs/cargo` are replaced by direct invokations of `cargo`.