### PR TITLE
Bump version to 1.47.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,8 +1,9 @@
 name: Rust
 
 on:
-  push: {}
-  pull_request: {}
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   build_test:
@@ -10,8 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust:
-        - 1.34.0
-        - 1.36.0
+        - 1.47.0
         - stable
         - beta
         - nightly
@@ -26,18 +26,15 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-    - name: Build the crate on minimal version.
+    # On MSRV some dev-dependencies don't build so we can't run tests.
+    - name: Check MSRV
+      if: matrix.rust == '1.47.0'
       run: |
-        cargo build
-    - name: Build the crate on 1.36 with features.
-      if: matrix.rust != '1.34.0'
+        cargo check --features=alloc,std,grab_spare_slice
+    - name: Test non nightly
+      if: matrix.rust != '1.47.0' && matrix.rust != 'nightly'
       run: |
-        # Using `extern crate alloc` is only possible after 1.36
-        cargo build --features=alloc,std,grab_spare_slice
-    - name: Test on Stable/Beta
-      if: matrix.rust != '1.34.0' && matrix.rust != '1.36.0'
-      run: |
-        cargo test --features=alloc --features=grab_spare_slice --features=rustc_1_40
+        cargo test --features=alloc,std,grab_spare_slice
     - name: Test on Nightly with All Features
       if: matrix.rust == 'nightly'
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,12 @@ std = ["alloc"]
 # "active" portion of an `ArrayVec` or `SliceVec`.
 grab_spare_slice = []
 
-# features that require rustc 1.40
-# use Vec::append if possible in TinyVec::append - 1.37
-# DoubleEndedIterator::nth_back - 1.40
+# obsolete feature that has to stay for semver reasons
 rustc_1_40 = []
 
 # features that require rustc 1.55
 # use const generics to implement Array for all array lengths
-rustc_1_55 = ["rustc_1_40"]
+rustc_1_55 = []
 
 # features that require rustc 1.57
 # add try_reserve functions to types that heap allocate.
@@ -64,11 +62,11 @@ experimental_write_impl = []
 real_blackbox = ["criterion/real_blackbox"]
 
 [package.metadata.docs.rs]
-features = ["alloc", "std", "grab_spare_slice", "rustc_1_40", "rustc_1_55", "serde"]
+features = ["alloc", "std", "grab_spare_slice", "rustc_1_55", "serde"]
 rustdoc-args = ["--cfg","docs_rs"]
 
 [package.metadata.playground]
-features = ["alloc", "std", "grab_spare_slice", "rustc_1_40", "rustc_1_55", "serde"]
+features = ["alloc", "std", "grab_spare_slice", "rustc_1_55", "serde"]
 
 [profile.test]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License:Zlib](https://img.shields.io/badge/License-Zlib-brightgreen.svg)](https://opensource.org/licenses/Zlib)
-![Minimum Rust Version](https://img.shields.io/badge/Min%20Rust-1.34-green.svg)
+![Minimum Rust Version](https://img.shields.io/badge/Min%20Rust-1.47-green.svg)
 [![crates.io](https://img.shields.io/crates/v/tinyvec.svg)](https://crates.io/crates/tinyvec)
 [![docs.rs](https://docs.rs/tinyvec/badge.svg)](https://docs.rs/tinyvec/)
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,4 +13,4 @@ better-panic = "0.2.0"
 
 [dependencies.tinyvec]
 path = ".."
-features = ["rustc_1_40", "grab_spare_slice", "alloc", "nightly_slice_partition_dedup"]
+features = ["grab_spare_slice", "alloc", "nightly_slice_partition_dedup"]

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -132,7 +132,7 @@ where
     if let Some(to_drop) =
       self.data.as_slice_mut().get_mut((o.len as usize)..(self.len as usize))
     {
-      to_drop.iter_mut().for_each(|x| drop(take(x)));
+      to_drop.iter_mut().for_each(|x| drop(core::mem::take(x)));
     }
     self.len = o.len;
   }
@@ -284,7 +284,7 @@ impl<A: Array> ArrayVec<A> {
       return Some(other);
     }
 
-    let iter = other.iter_mut().map(take);
+    let iter = other.iter_mut().map(core::mem::take);
     for item in iter {
       self.push(item);
     }
@@ -605,7 +605,8 @@ impl<A: Array> ArrayVec<A> {
   pub fn pop(&mut self) -> Option<A::Item> {
     if self.len > 0 {
       self.len -= 1;
-      let out = take(&mut self.data.as_slice_mut()[self.len as usize]);
+      let out =
+        core::mem::take(&mut self.data.as_slice_mut()[self.len as usize]);
       Some(out)
     } else {
       None
@@ -680,7 +681,7 @@ impl<A: Array> ArrayVec<A> {
   #[inline]
   pub fn remove(&mut self, index: usize) -> A::Item {
     let targets: &mut [A::Item] = &mut self.deref_mut()[index..];
-    let item = take(&mut targets[0]);
+    let item = core::mem::take(&mut targets[0]);
 
     // A previous implementation used rotate_left
     // rotate_right and rotate_left generate a huge amount of code and fail to
@@ -794,7 +795,7 @@ impl<A: Array> ArrayVec<A> {
     for idx in 0..len {
       // Loop start invariant: idx = rest.done_end + rest.tail_start
       if !acceptable(&rest.items[idx]) {
-        let _ = take(&mut rest.items[idx]);
+        let _ = core::mem::take(&mut rest.items[idx]);
         self.len -= 1;
         rest.tail_start += 1;
       } else {
@@ -983,7 +984,7 @@ impl<A: Array> ArrayVec<A> {
       let len = self.len as usize;
       self.data.as_slice_mut()[new_len..len]
         .iter_mut()
-        .map(take)
+        .map(core::mem::take)
         .for_each(drop);
     }
 
@@ -1358,7 +1359,7 @@ impl<A: Array> Iterator for ArrayVecIterator<A> {
       &mut self.data.as_slice_mut()[self.base as usize..self.tail as usize];
     let itemref = slice.first_mut()?;
     self.base += 1;
-    return Some(take(itemref));
+    return Some(core::mem::take(itemref));
   }
   #[inline(always)]
   #[must_use]
@@ -1383,7 +1384,7 @@ impl<A: Array> Iterator for ArrayVecIterator<A> {
     if let Some(x) = slice.get_mut(n) {
       /* n is in range [0 .. self.tail - self.base) so in u16 range */
       self.base += n as u16 + 1;
-      return Some(take(x));
+      return Some(core::mem::take(x));
     }
 
     self.base = self.tail;
@@ -1398,9 +1399,9 @@ impl<A: Array> DoubleEndedIterator for ArrayVecIterator<A> {
       &mut self.data.as_slice_mut()[self.base as usize..self.tail as usize];
     let item = slice.last_mut()?;
     self.tail -= 1;
-    return Some(take(item));
+    return Some(core::mem::take(item));
   }
-  #[cfg(feature = "rustc_1_40")]
+
   #[inline]
   fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
     let base = self.base as usize;
@@ -1412,7 +1413,7 @@ impl<A: Array> DoubleEndedIterator for ArrayVecIterator<A> {
       let item = &mut slice[n];
       /* n is in [0..self.tail - self.base] range, so in u16 range */
       self.tail = self.base + n as u16;
-      return Some(take(item));
+      return Some(core::mem::take(item));
     }
 
     self.tail = self.base;
@@ -1778,7 +1779,7 @@ impl<A: Array> ArrayVec<A> {
   pub fn drain_to_vec_and_reserve(&mut self, n: usize) -> Vec<A::Item> {
     let cap = n + self.len();
     let mut v = Vec::with_capacity(cap);
-    let iter = self.iter_mut().map(take);
+    let iter = self.iter_mut().map(core::mem::take);
     v.extend(iter);
     self.set_len(0);
     return v;
@@ -1806,7 +1807,7 @@ impl<A: Array> ArrayVec<A> {
     let cap = n + self.len();
     let mut v = Vec::new();
     v.try_reserve(cap)?;
-    let iter = self.iter_mut().map(take);
+    let iter = self.iter_mut().map(core::mem::take);
     v.extend(iter);
     self.set_len(0);
     return Ok(v);

--- a/src/arrayvec_drain.rs
+++ b/src/arrayvec_drain.rs
@@ -57,34 +57,33 @@ impl<'a, T: 'a + Default> ArrayVecDrain<'a, T> {
 
 impl<'a, T: 'a + Default> DoubleEndedIterator for ArrayVecDrain<'a, T> {
   fn next_back(&mut self) -> Option<Self::Item> {
-    self.iter.next_back().map(take)
+    self.iter.next_back().map(core::mem::take)
   }
 
-  #[cfg(feature = "rustc_1_40")]
   fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-    self.iter.nth_back(n).map(take)
+    self.iter.nth_back(n).map(core::mem::take)
   }
 }
 
 impl<'a, T: 'a + Default> Iterator for ArrayVecDrain<'a, T> {
   type Item = T;
   fn next(&mut self) -> Option<Self::Item> {
-    self.iter.next().map(take)
+    self.iter.next().map(core::mem::take)
   }
   fn size_hint(&self) -> (usize, Option<usize>) {
     self.iter.size_hint()
   }
   fn nth(&mut self, n: usize) -> Option<Self::Item> {
-    self.iter.nth(n).map(take)
+    self.iter.nth(n).map(core::mem::take)
   }
   fn last(self) -> Option<Self::Item> {
-    self.iter.last().map(take)
+    self.iter.last().map(core::mem::take)
   }
   fn for_each<F>(self, f: F)
   where
     F: FnMut(Self::Item),
   {
-    self.iter.map(take).for_each(f)
+    self.iter.map(core::mem::take).for_each(f)
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,6 @@
 //! ## Other Features
 //! * `grab_spare_slice` lets you get access to the "inactive" portions of an
 //!   ArrayVec.
-//! * `rustc_1_40` makes the crate assume a minimum rust version of `1.40.0`,
-//!   which allows some better internal optimizations.
 //! * `serde` provides a `Serialize` and `Deserialize` implementation for
 //!   [`TinyVec`] and [`ArrayVec`] types, provided the inner item also has an
 //!   implementation.
@@ -104,9 +102,3 @@ pub use slicevec::*;
 mod tinyvec;
 #[cfg(feature = "alloc")]
 pub use crate::tinyvec::*;
-
-// TODO MSRV(1.40.0): Just call the normal `core::mem::take`
-#[inline(always)]
-fn take<T: Default>(from: &mut T) -> T {
-  replace(from, T::default())
-}

--- a/src/slicevec.rs
+++ b/src/slicevec.rs
@@ -326,7 +326,7 @@ impl<'s, T> SliceVec<'s, T> {
   {
     if self.len > 0 {
       self.len -= 1;
-      let out = take(&mut self.data[self.len]);
+      let out = core::mem::take(&mut self.data[self.len]);
       Some(out)
     } else {
       None
@@ -383,7 +383,7 @@ impl<'s, T> SliceVec<'s, T> {
     T: Default,
   {
     let targets: &mut [T] = &mut self.deref_mut()[index..];
-    let item = take(&mut targets[0]);
+    let item = core::mem::take(&mut targets[0]);
     targets.rotate_left(1);
     self.len -= 1;
     item
@@ -500,7 +500,7 @@ impl<'s, T> SliceVec<'s, T> {
     for idx in 0..self.len {
       // Loop start invariant: idx = rest.done_end + rest.tail_start
       if !acceptable(&rest.items[idx]) {
-        let _ = take(&mut rest.items[idx]);
+        let _ = core::mem::take(&mut rest.items[idx]);
         self.len -= 1;
         rest.tail_start += 1;
       } else {
@@ -724,7 +724,7 @@ impl<'p, 's, T: Default> Iterator for SliceVecDrain<'p, 's, T> {
   #[inline]
   fn next(&mut self) -> Option<Self::Item> {
     if self.target_index != self.target_end {
-      let out = take(&mut self.parent[self.target_index]);
+      let out = core::mem::take(&mut self.parent[self.target_index]);
       self.target_index += 1;
       Some(out)
     } else {

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -530,7 +530,6 @@ impl<A: Array> TinyVec<A> {
 
 impl<A: Array> TinyVec<A> {
   /// Move all values from `other` into this vec.
-  #[cfg(feature = "rustc_1_40")]
   #[inline]
   pub fn append(&mut self, other: &mut Self) {
     self.reserve(other.len());
@@ -540,16 +539,6 @@ impl<A: Array> TinyVec<A> {
       (TinyVec::Heap(sh), TinyVec::Heap(oh)) => sh.append(oh),
       (TinyVec::Inline(a), TinyVec::Heap(h)) => a.extend(h.drain(..)),
       (ref mut this, TinyVec::Inline(arr)) => this.extend(arr.drain(..)),
-    }
-  }
-
-  /// Move all values from `other` into this vec.
-  #[cfg(not(feature = "rustc_1_40"))]
-  #[inline]
-  pub fn append(&mut self, other: &mut Self) {
-    match other {
-      TinyVec::Inline(a) => self.extend(a.drain(..)),
-      TinyVec::Heap(h) => self.extend(h.drain(..)),
     }
   }
 
@@ -1101,7 +1090,6 @@ impl<'p, A: Array> DoubleEndedIterator for TinyVecDrain<'p, A> {
     #[inline]
     fn next_back(self: &mut Self) -> Option<Self::Item>;
 
-    #[cfg(feature = "rustc_1_40")]
     #[inline]
     fn nth_back(self: &mut Self, n: usize) -> Option<Self::Item>;
   }
@@ -1380,7 +1368,6 @@ impl<A: Array> DoubleEndedIterator for TinyVecIterator<A> {
     #[inline]
     fn next_back(self: &mut Self) -> Option<Self::Item>;
 
-    #[cfg(feature = "rustc_1_40")]
     #[inline]
     fn nth_back(self: &mut Self, n: usize) -> Option<Self::Item>;
   }

--- a/tests/debugger_visualizer.rs
+++ b/tests/debugger_visualizer.rs
@@ -3,12 +3,12 @@ use tinyvec::*;
 
 #[inline(never)]
 fn __break() {
-    println!("breakpoint hit");
+  println!("breakpoint hit");
 }
 
 #[debugger_test(
-    debugger = "cdb",
-    commands = r#"
+  debugger = "cdb",
+  commands = r#"
 dx strings
 dx inline_tv
 dx inline_tv.__0
@@ -17,7 +17,7 @@ dx slice_vec
 g
 dx strings
 "#,
-    expected_statements = r#"
+  expected_statements = r#"
 pattern:strings          : \{ len=0x3 \} \[Type: tinyvec::arrayvec::ArrayVec<array\$<.*str.*,7> >\]
 pattern:\[<Raw View>\]     \[Type: tinyvec::arrayvec::ArrayVec<array\$<.*str.*,7> >\]
 pattern:\[len\]            : 0x3 \[Type: unsigned short\]
@@ -60,32 +60,32 @@ pattern:\[5\]              : "g" \[Type: .*str.*\]
 )]
 #[inline(never)]
 fn test_debugger_visualizer() {
-    let mut strings = ArrayVec::<[&str; 7]>::default();
-    strings.push("a");
-    strings.push("b");
-    strings.push("c");
-    assert_eq!(["a", "b", "c"], &strings[..]);
+  let mut strings = ArrayVec::<[&str; 7]>::default();
+  strings.push("a");
+  strings.push("b");
+  strings.push("c");
+  assert_eq!(["a", "b", "c"], &strings[..]);
 
-    let mut inline_tv = tiny_vec!([i32; 4] => 1, 2, 3);
-    assert!(inline_tv.is_inline());
+  let mut inline_tv = tiny_vec!([i32; 4] => 1, 2, 3);
+  assert!(inline_tv.is_inline());
 
-    inline_tv.push(4);
+  inline_tv.push(4);
+  __break();
+
+  {
+    let mut slice_vec = SliceVec::from(strings.as_mut_slice());
+    assert_eq!(3, slice_vec.capacity());
+    assert_eq!("c", slice_vec.remove(2));
+    slice_vec.push("d");
+    println!("{:?}", slice_vec);
     __break();
 
-    {
-        let mut slice_vec = SliceVec::from(strings.as_mut_slice());
-        assert_eq!(3, slice_vec.capacity());
-        assert_eq!("c", slice_vec.remove(2));
-        slice_vec.push("d");
-        println!("{:?}", slice_vec);
-        __break();
+    assert_eq!(["a", "b", "d"], &slice_vec[..]);
+  }
 
-        assert_eq!(["a", "b", "d"], &slice_vec[..]);
-    }
-
-    strings.push("e");
-    strings.push("f");
-    strings.push("g");
-    assert_eq!(["a", "b", "d", "e", "f", "g"], &strings[..]);
-    __break();
+  strings.push("e");
+  strings.push("f");
+  strings.push("g");
+  assert_eq!(["a", "b", "d", "e", "f", "g"], &strings[..]);
+  __break();
 }


### PR DESCRIPTION
- Delete checks for `rustc_1.40` feature.
- Make CI not run all jobs twice for pull requests.
- Change MSRV CI run to use `cargo check` because that's more efficient
  than `cargo build`.
- Run `cargo fmt` which reformats some otherwise untouched code.