### PR TITLE
Add bincode enc/dec support to ArrayVec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.tool-versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ tinyvec_macros = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, default-features = false }
 # Provides derived `Arbitrary` implementations
 arbitrary = { version = "1", optional = true }
+# Provides 'Encode' and 'Decode' implmentations.
+bincode = { version = "2.0.0-rc.3", optional = true }
 
 [features]
 default = []
@@ -62,11 +64,11 @@ experimental_write_impl = []
 real_blackbox = ["criterion/real_blackbox"]
 
 [package.metadata.docs.rs]
-features = ["alloc", "std", "grab_spare_slice", "rustc_1_55", "serde"]
+features = ["alloc", "std", "grab_spare_slice", "rustc_1_55", "serde", "bincode"]
 rustdoc-args = ["--cfg","docs_rs"]
 
 [package.metadata.playground]
-features = ["alloc", "std", "grab_spare_slice", "rustc_1_55", "serde"]
+features = ["alloc", "std", "grab_spare_slice", "rustc_1_55", "serde", "bincode"]
 
 [profile.test]
 opt-level = 3

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -9,6 +9,8 @@ use serde::de::{
 };
 #[cfg(feature = "serde")]
 use serde::ser::{Serialize, SerializeSeq, Serializer};
+#[cfg(feature = "bincode")]
+use bincode::{error::{DecodeError, EncodeError}, de::Decoder, enc::Encoder, Encode, Decode};
 
 /// Helper to make an `ArrayVec`.
 ///
@@ -216,6 +218,33 @@ where
   {
     deserializer.deserialize_seq(ArrayVecVisitor(PhantomData))
   }
+}
+
+#[cfg(feature = "bincode")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "bincode")))]
+impl<T> Decode for ArrayVec<T>
+where
+    T: Array + Decode + 'static,
+{
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+
+      let arr = T::decode(decoder)?;
+      let vec = ArrayVec::from(arr);
+
+      Ok(vec)
+    }
+}
+
+#[cfg(feature = "bincode")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "bincode")))]
+impl<T> Encode for ArrayVec<T>
+where
+    T: Array + Encode + 'static,
+{
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+      self.data.encode(encoder)?;
+      Ok(())
+    }
 }
 
 #[cfg(feature = "arbitrary")]

--- a/tests/arrayvec.rs
+++ b/tests/arrayvec.rs
@@ -446,6 +446,36 @@ fn ArrayVec_ser_de() {
   );
 }
 
+#[cfg(feature = "bincode")]
+#[test]
+fn ArrayVec_bin_de() {
+  let mut tv: ArrayVec<[i32; 4]> = Default::default();
+  let config = bincode::config::standard();
+  tv.push(1);
+  tv.push(2);
+  tv.push(3);
+  tv.push(4);
+
+  let encoded = bincode::encode_to_vec(&tv, config).unwrap();
+
+  let (decoded, _): (ArrayVec<[i32; 4]>, _) = bincode::decode_from_slice(&encoded[..], config).expect("Expected decode to ArrayVec.");
+
+  assert!(tv == decoded)
+}
+
+#[cfg(feature = "bincode")]
+#[test]
+fn ArrayVec_bin_enc() {
+  let mut tv: ArrayVec<[i32; 4]> = Default::default();
+  let config = bincode::config::standard();
+  tv.push(1);
+  tv.push(2);
+  tv.push(3);
+  tv.push(4);
+
+  bincode::encode_to_vec(&tv, config).expect("Expected encode into Vec<u8>");
+}
+
 #[test]
 fn ArrayVec_try_from_slice() {
   use std::convert::TryFrom;


### PR DESCRIPTION
Adds enc/dec support to tinyvec's ArrayVec for bincode, https://github.com/bincode-org/bincode.