### PR TITLE
Add ArrayVec::as_inner()

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -341,6 +341,16 @@ impl<A: Array> ArrayVec<A> {
     self.deref()
   }
 
+  /// Returns the reference to the inner array of the `ArrayVec`.
+  ///
+  /// This returns the full array, even if the `ArrayVec` length is currently
+  /// less than that.
+  #[inline(always)]
+  #[must_use]
+  pub const fn as_inner(&self) -> &A {
+    &self.data
+  }
+
   /// The capacity of the `ArrayVec`.
   ///
   /// This is fixed based on the array type, but can't yet be made a `const fn`


### PR DESCRIPTION
Originally I was going to call this `as_array()`
but `as_inner()` is more consistent with the
existing `into_inner()` method. I don't
_ultimately_ care what it ends up being called.

I wonder if we should have a `impl
From<ArrayVec<T>> for A` implementation or is that a bit too foot-gun-y?

Fixes #193.