### PR TITLE
Add retain_mut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ rustc_1_55 = []
 # add try_reserve functions to types that heap allocate.
 rustc_1_57 = ["rustc_1_55"]
 
+# features that require rustc 1.61
+# add retain_mut function to TinyVec
+rustc_1_61 = []
+
 # allow use of nightly feature `slice_partition_dedup`,
 # will become useless once that is stabilized:
 # https://github.com/rust-lang/rust/issues/54279

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1950,3 +1950,45 @@ where
     Ok(new_arrayvec)
   }
 }
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn retain_mut_empty_vec() {
+    let mut av: ArrayVec<[i32; 4]> = ArrayVec::new();
+    av.retain_mut(|&mut x| x % 2 == 0);
+    assert_eq!(av.len(), 0);
+  }
+
+  #[test]
+  fn retain_mut_all_elements() {
+    let mut av: ArrayVec<[i32; 4]> = array_vec!([i32; 4] => 2, 4, 6, 8);
+    av.retain_mut(|&mut x| x % 2 == 0);
+    assert_eq!(av.len(), 4);
+    assert_eq!(av.as_slice(), &[2, 4, 6, 8]);
+  }
+
+  #[test]
+  fn retain_mut_some_elements() {
+    let mut av: ArrayVec<[i32; 4]> = array_vec!([i32; 4] => 1, 2, 3, 4);
+    av.retain_mut(|&mut x| x % 2 == 0);
+    assert_eq!(av.len(), 2);
+    assert_eq!(av.as_slice(), &[2, 4]);
+  }
+
+  #[test]
+  fn retain_mut_no_elements() {
+    let mut av: ArrayVec<[i32; 4]> = array_vec!([i32; 4] => 1, 3, 5, 7);
+    av.retain_mut(|&mut x| x % 2 == 0);
+    assert_eq!(av.len(), 0);
+  }
+
+  #[test]
+  fn retain_mut_zero_capacity() {
+    let mut av: ArrayVec<[i32; 0]> = ArrayVec::new();
+    av.retain_mut(|&mut x| x % 2 == 0);
+    assert_eq!(av.len(), 0);
+  }
+}

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -647,6 +647,26 @@ impl<A: Array> TinyVec<A> {
     }
   }
 
+  /// Walk the vec and keep only the elements that pass the predicate given,
+  /// having the opportunity to modify the elements at the same time.
+  ///
+  /// ## Example
+  ///
+  /// ```rust
+  /// use tinyvec::*;
+  ///
+  /// let mut tv = tiny_vec!([i32; 10] => 1, 2, 3, 4);
+  /// tv.retain_mut(|x| if *x % 2 == 0 { *x *= 2; true } else { false });
+  /// assert_eq!(tv.as_slice(), &[4, 8][..]);
+  /// ```
+  #[inline]
+  pub fn retain_mut<F: FnMut(&mut A::Item) -> bool>(&mut self, acceptable: F) {
+    match self {
+      TinyVec::Inline(i) => i.retain_mut(acceptable),
+      TinyVec::Heap(h) => h.retain_mut(acceptable),
+    }
+  }
+
   /// Helper for getting the mut slice.
   #[inline(always)]
   #[must_use]

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -660,6 +660,7 @@ impl<A: Array> TinyVec<A> {
   /// assert_eq!(tv.as_slice(), &[4, 8][..]);
   /// ```
   #[inline]
+  #[cfg(feature = "rustc_1_61")]
   pub fn retain_mut<F: FnMut(&mut A::Item) -> bool>(&mut self, acceptable: F) {
     match self {
       TinyVec::Inline(i) => i.retain_mut(acceptable),


### PR DESCRIPTION
This adds a `retain_mut` method to `ArrayVec` and
`TinyVec` that's just `retain` but with mutable
references. This method is present on
`std::vec::Vec` as of a while ago so it's nice to
have in `tinyvec` too.

Fixes #195