### PR TITLE
Fix rustc features not depending on each other

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustc_1_40 = []
 
 # features that require rustc 1.55
 # use const generics to implement Array for all array lengths
-rustc_1_55 = []
+rustc_1_55 = ["rustc_1_40"]
 
 # features that require rustc 1.57
 # add try_reserve functions to types that heap allocate.
@@ -43,7 +43,7 @@ rustc_1_57 = ["rustc_1_55"]
 
 # features that require rustc 1.61
 # add retain_mut function to TinyVec
-rustc_1_61 = []
+rustc_1_61 = ["rustc_1_57"]
 
 # allow use of nightly feature `slice_partition_dedup`,
 # will become useless once that is stabilized:


### PR DESCRIPTION
This crate has several features related to the rustc version. It is currently a bug that not all off these features depend on the lower rustc version features. This commit fixes this.

This bug leads to bad user experience. For example, you notice that by default tinyvec doesn't work with arrays of all sizes. The docs tell you to enable the rustc_1_55 feature to fix this. You see that there are features for even newer rustc versions so you pick the most recent one because you use the current stable compiler. To your surprise, this does not enable tinyvec to work with arrays of all sizes.

This change is correct because features are additive and rustc versions are backward compatible.