### PR TITLE
Add support for `generic-array` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ tinyvec_macros = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, default-features = false }
 # Provides derived `Arbitrary` implementations
 arbitrary = { version = "1", optional = true }
+# Implements the trait `Array` for `GenericArray` struct.
+generic-array = { version = "1.1.1", optional = true, default-features = false }
 
 [features]
 default = []

--- a/src/array.rs
+++ b/src/array.rs
@@ -41,8 +41,14 @@ pub trait Array {
   fn default() -> Self;
 }
 
+#[cfg(all(feature = "generic-array", not(feature = "rustc_1_55")))]
+core::compile_error!("generic-array requires `rustc_1_55` feature");
+
 #[cfg(feature = "rustc_1_55")]
 mod const_generic_impl;
 
 #[cfg(not(feature = "rustc_1_55"))]
 mod generated_impl;
+
+#[cfg(feature = "generic-array")]
+mod generic_array_impl;

--- a/src/array/generic_array_impl.rs
+++ b/src/array/generic_array_impl.rs
@@ -1,0 +1,26 @@
+use core::default;
+
+use super::Array;
+use generic_array::{ArrayLength, GenericArray};
+
+impl<T: Default, N: ArrayLength> Array for GenericArray<T, N> {
+  type Item = T;
+  const CAPACITY: usize = N::USIZE;
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice(&self) -> &[T] {
+    &*self
+  }
+
+  #[inline(always)]
+  #[must_use]
+  fn as_slice_mut(&mut self) -> &mut [T] {
+    &mut *self
+  }
+
+  #[inline(always)]
+  fn default() -> Self {
+    <Self as Default>::default()
+  }
+}


### PR DESCRIPTION
In working in a `no_std` library and to create an `ArrayVec` where the length is provided by [ArrayLength](https://docs.rs/generic-array/latest/generic_array/trait.ArrayLength.html) trait, and realized this was not possible. once is not possible to implement the trait [Array](https://docs.rs/tinyvec/latest/tinyvec/trait.Array.html) for third-party crates, the only options are either [generic-array](https://docs.rs/generic-array/latest/generic_array/) add [tinyvec](https://docs.rs/tinyvec/latest/tinyvec/) as optional dependency and implement the needed trait, or vice-versa.

So this PR implements the trait [Array](https://docs.rs/tinyvec/latest/tinyvec/trait.Array.html) for [GenericArray](https://docs.rs/generic-array/latest/generic_array/struct.GenericArray.html). Combining both I can have trait defined length and the resizable array. 

This adds support for generic trait-defined types and length, example:
```rust
use generic_array::{ArrayLength, GenericArray};
use tinyvec::{TinyVec, ArrayVec, Array};

pub type GenericArrayVec<T, N> = ArrayVec<GenericArray<T, N>>;
pub type GenericTinyVec<T, N> = TinyVec<GenericArray<T, N>>;

pub trait Config {
    type MaxSize: ArrayLength;
    type Value: Sized + Send + 'static;
}

pub struct Foo<T: Config> {
    pub values: GenericArrayVec<T::Value, T::MaxSize>;
}
```