### PR TITLE
Make Debug instances behave like those for slices

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1712,20 +1712,7 @@ where
 {
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-    write!(f, "[")?;
-    if f.alternate() && !self.is_empty() {
-      write!(f, "\n    ")?;
-    }
-    for (i, elem) in self.iter().enumerate() {
-      if i > 0 {
-        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
-      }
-      Debug::fmt(elem, f)?;
-    }
-    if f.alternate() && !self.is_empty() {
-      write!(f, ",\n")?;
-    }
-    write!(f, "]")
+    <[A::Item] as Debug>::fmt(self.as_slice(), f)
   }
 }
 
@@ -2055,5 +2042,27 @@ mod test {
     let mut av: ArrayVec<[i32; 0]> = ArrayVec::new();
     av.retain_mut(|&mut x| x % 2 == 0);
     assert_eq!(av.len(), 0);
+  }
+
+  #[cfg(feature = "alloc")]
+  #[test]
+  fn array_like_debug() {
+    #[derive(Debug, Default, Copy, Clone)]
+    struct S {
+      x: u8,
+      y: u8,
+    }
+
+    use core::fmt::Write;
+
+    let mut ar: [S; 2] = [S { x: 1, y: 2 }, S { x: 3, y: 4 }];
+    let mut buf_ar = alloc::string::String::new();
+    write!(&mut buf_ar, "{ar:#?}");
+
+    let av: ArrayVec<[S; 2]> = ArrayVec::from(ar);
+    let mut buf_av = alloc::string::String::new();
+    write!(&mut buf_av, "{av:#?}");
+
+    assert_eq!(buf_av, buf_ar)
   }
 }

--- a/src/slicevec.rs
+++ b/src/slicevec.rs
@@ -890,20 +890,7 @@ where
 {
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-    write!(f, "[")?;
-    if f.alternate() && !self.is_empty() {
-      write!(f, "\n    ")?;
-    }
-    for (i, elem) in self.iter().enumerate() {
-      if i > 0 {
-        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
-      }
-      Debug::fmt(elem, f)?;
-    }
-    if f.alternate() && !self.is_empty() {
-      write!(f, ",\n")?;
-    }
-    write!(f, "]")
+    <[T] as Debug>::fmt(self.as_slice(), f)
   }
 }
 
@@ -1065,5 +1052,32 @@ where
       write!(f, ",\n")?;
     }
     write!(f, "]")
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[cfg(feature = "alloc")]
+  #[test]
+  fn array_like_debug() {
+    #[derive(Debug, Default, Copy, Clone)]
+    struct S {
+      x: u8,
+      y: u8,
+    }
+
+    use core::fmt::Write;
+
+    let mut ar: [S; 2] = [S { x: 1, y: 2 }, S { x: 3, y: 4 }];
+    let mut buf_ar = alloc::string::String::new();
+    write!(&mut buf_ar, "{ar:#?}");
+
+    let av: SliceVec<S> = SliceVec::from(&mut ar);
+    let mut buf_av = alloc::string::String::new();
+    write!(&mut buf_av, "{av:#?}");
+
+    assert_eq!(buf_av, buf_ar)
   }
 }

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -1676,20 +1676,7 @@ where
 {
   #[allow(clippy::missing_inline_in_public_items)]
   fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-    write!(f, "[")?;
-    if f.alternate() && !self.is_empty() {
-      write!(f, "\n    ")?;
-    }
-    for (i, elem) in self.iter().enumerate() {
-      if i > 0 {
-        write!(f, ",{}", if f.alternate() { "\n    " } else { " " })?;
-      }
-      Debug::fmt(elem, f)?;
-    }
-    if f.alternate() && !self.is_empty() {
-      write!(f, ",\n")?;
-    }
-    write!(f, "]")
+    <[A::Item] as Debug>::fmt(self.as_slice(), f)
   }
 }
 

--- a/tests/tinyvec.rs
+++ b/tests/tinyvec.rs
@@ -499,3 +499,25 @@ fn TinyVec_std_io_write() {
   assert!(tv.is_heap());
   assert_eq!(tv, tiny_vec![b'f', b'o', b'o', b'b', b'a', b'r']);
 }
+
+#[cfg(feature = "alloc")]
+#[test]
+fn TinyVec_array_like_debug() {
+  #[derive(Debug, Default, Copy, Clone)]
+  struct S {
+    x: u8,
+    y: u8,
+  }
+
+  use core::fmt::Write;
+
+  let mut ar: [S; 2] = [S { x: 1, y: 2 }, S { x: 3, y: 4 }];
+  let mut buf_ar = alloc::string::String::new();
+  write!(&mut buf_ar, "{ar:#?}");
+
+  let av: TinyVec<[S; 2]> = TinyVec::from(ar);
+  let mut buf_av = alloc::string::String::new();
+  write!(&mut buf_av, "{av:#?}");
+
+  assert_eq!(buf_av, buf_ar)
+}


### PR DESCRIPTION
The indentantion in case of structs inside the
arrays was wrong with pretty debug instance.
Instead of rolling one by hand, just use the
underlying slice implementation. It appears that
this was even the intention orginally, based on
the `TinyVec_pretty_debug` test. The main issue is that the test used a simple value instead of a
struct so it missed the problem. FWIW I have kept
the existing test but I think it could just be
deleted now.

I haven't touched the `Display` version because
while slices have a `Debug` impl, there isn't one
for `Display`. So I think probably `Display` has
the same problem.

These tests can technically be written in a
non-alloc/non-std way by defining an array-backed
buffer and giving it `core::fmt::Write` but I was
too lazy to do so: it doesn't seem useful.

Fixes #192.