### PR TITLE
upgrade criterion to 0.8 series

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ debug = 2
 members = ["fuzz"]
 
 [dev-dependencies]
-criterion = "0.3.0"
+criterion = "0.8.0"
 serde_test = "1.0"
 smallvec = "1"
 debugger_test = "0.1"


### PR DESCRIPTION
inspired by: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/tinyvec/debian/patches/relax-deps.patch?ref_type=heads