### PR TITLE
Add support for hybrid-array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ serde_core = { version = "1.0", optional = true, default-features = false }
 arbitrary = { version = "1", optional = true }
 # Provides `BorshSerialize` and `BorshDeserialize implementations
 borsh = { version = "1.2.0", optional = true, default-features = false }
-# Implements the trait `Array` for `GenericArray` struct.
-generic-array = { version = "1.1.1", optional = true, default-features = false }
+# Implements the trait `tinyvec::Array` for `GenericArray` struct.
+generic-array = { version = "1.4.1", optional = true, default-features = false }
+# Implements the trait `tinyvec::Array` for `hybrid_array::Array` struct.
+hybrid-array = { version = "0.4.12", optional = true, default-features = false }
 # Provides derived `BitEncode` and `BitDecode` implementations
 bin-proto = { version = "0.12.5", optional = true, default-features = false }
 # Provides `Format` implementations
@@ -30,13 +32,13 @@ defmt = { version = "1.0", optional = true }
 default = []
 
 # Provide things that utilize the `alloc` crate, namely `TinyVec`.
-alloc = ["tinyvec_macros"]
+alloc = ["tinyvec_macros", "hybrid-array?/alloc", "generic-array?/alloc"]
 
 # Provide things that require Rust's `std` module
 std = ["alloc"]
 
 # Provides `Serialize` and `Deserialize` implementations
-serde = ["dep:serde_core"]
+serde = ["dep:serde_core", "hybrid-array?/serde", "generic-array?/serde"]
 
 # (not part of Vec!) Extra methods to let you grab the slice of memory after the
 # "active" portion of an `ArrayVec` or `SliceVec`.
@@ -81,6 +83,9 @@ experimental_write_impl = []
 # which is based on read_volatile. This feature requires inline assembly
 # and thus a nightly compiler, but is only used in benchmarks.
 real_blackbox = ["criterion/real_blackbox"]
+
+# enable third-part support
+arbitrary = ["dep:arbitrary", "hybrid-array?/arbitrary", "generic-array?/arbitrary"]
 
 [package.metadata.docs.rs]
 features = ["alloc", "std", "grab_spare_slice", "latest_stable_rust", "serde", "borsh", "defmt", "bin-proto"]

--- a/src/array.rs
+++ b/src/array.rs
@@ -42,3 +42,6 @@ mod const_generic_impl;
 
 #[cfg(feature = "generic-array")]
 mod generic_array_impl;
+
+#[cfg(feature = "hybrid-array")]
+mod hybrid_array_impl;

--- a/src/array/generic_array_impl.rs
+++ b/src/array/generic_array_impl.rs
@@ -85,11 +85,11 @@ mod test {
 
     let mut ar: ConstGenericArray<S, 2> = ConstGenericArray::<S, 2>::from_array([S { x: 1, y: 2 }, S { x: 3, y: 4 }]);
     let mut buf_ar = String::new();
-    write!(&mut buf_ar, "{ar:#?}");
+    write!(&mut buf_ar, "{:#?}", ar.as_slice()).unwrap();
 
     let av: TinyGenericVec<S, 2> = TinyGenericVec::<S, 2>::from_array_len(ar, 2);
     let mut buf_av = String::new();
-    write!(&mut buf_av, "{av:#?}");
+    write!(&mut buf_av, "{av:#?}").unwrap();
 
     assert_eq!(buf_av, buf_ar)
   }

--- a/src/array/hybrid_array_impl.rs
+++ b/src/array/hybrid_array_impl.rs
@@ -1,20 +1,20 @@
 use core::default;
 
 use super::Array;
-use generic_array::{ArrayLength, GenericArray, IntoArrayLength};
+use hybrid_array::{Array as HybridArray, AssocArraySize, ArraySize, typenum::Unsigned};
 
-impl<T: Default, N: ArrayLength> Array for GenericArray<T, N> {
+impl<T: Default, N: ArraySize> Array for HybridArray<T, N> {
   type Item = T;
-  const CAPACITY: usize = N::USIZE;
+  const CAPACITY: usize = <N as Unsigned>::USIZE;
 
   #[inline(always)]
   fn as_slice(&self) -> &[T] {
-    GenericArray::as_slice(self)
+    HybridArray::as_slice(self)
   }
 
   #[inline(always)]
   fn as_slice_mut(&mut self) -> &mut [T] {
-    GenericArray::as_mut_slice(self)
+    HybridArray::as_mut_slice(self)
   }
 
   #[inline(always)]
@@ -23,27 +23,27 @@ impl<T: Default, N: ArrayLength> Array for GenericArray<T, N> {
   }
 }
 
-impl <T> IntoArrayLength for crate::ArrayVec<T> where T: IntoArrayLength {
-    type ArrayLength = <T as IntoArrayLength>::ArrayLength;
+impl <T> AssocArraySize for crate::ArrayVec<T> where T: AssocArraySize {
+    type Size = <T as AssocArraySize>::Size;
 }
 
 #[cfg(test)]
 mod test {
   use super::*;
   use crate::{ArrayVec, array_vec};
-  use generic_array::ConstGenericArray;
-  type TinyGenericVec<T, const N: usize> = ArrayVec<ConstGenericArray<T, N>>;
+  use hybrid_array::ArrayN;
+  type TinyHybridVec<T, const N: usize> = ArrayVec<ArrayN<T, N>>;
 
   #[test]
   fn retain_mut_empty_vec() {
-    let mut av: TinyGenericVec<i32, 4> = TinyGenericVec::<i32, 4>::new();
+    let mut av: TinyHybridVec<i32, 4> = TinyHybridVec::<i32, 4>::new();
     av.retain_mut(|&mut x| x % 2 == 0);
     assert_eq!(av.len(), 0);
   }
 
   #[test]
   fn retain_mut_all_elements() {
-    let mut av: TinyGenericVec<i32, 4>  = array_vec!(ConstGenericArray<i32, 4> => 2, 4, 6, 8);
+    let mut av: TinyHybridVec<i32, 4>  = array_vec!(ArrayN<i32, 4> => 2, 4, 6, 8);
     av.retain_mut(|&mut x| x % 2 == 0);
     assert_eq!(av.len(), 4);
     assert_eq!(av.as_slice(), &[2, 4, 6, 8]);
@@ -51,7 +51,7 @@ mod test {
 
   #[test]
   fn retain_mut_some_elements() {
-    let mut av: TinyGenericVec<i32, 4>  = array_vec!(ConstGenericArray<i32, 4> => 1, 2, 3, 4);
+    let mut av: TinyHybridVec<i32, 4>  = array_vec!(ArrayN<i32, 4> => 1, 2, 3, 4);
     av.retain_mut(|&mut x| x % 2 == 0);
     assert_eq!(av.len(), 2);
     assert_eq!(av.as_slice(), &[2, 4]);
@@ -59,14 +59,14 @@ mod test {
 
   #[test]
   fn retain_mut_no_elements() {
-    let mut av: TinyGenericVec<i32, 4>  = array_vec!(ConstGenericArray<i32, 4> => 1, 3, 5, 7);
+    let mut av: TinyHybridVec<i32, 4>  = array_vec!(ArrayN<i32, 4> => 1, 3, 5, 7);
     av.retain_mut(|&mut x| x % 2 == 0);
     assert_eq!(av.len(), 0);
   }
 
   #[test]
   fn retain_mut_zero_capacity() {
-    let mut av: TinyGenericVec<i32, 0>  = ArrayVec::new();
+    let mut av: TinyHybridVec<i32, 0>  = ArrayVec::new();
     av.retain_mut(|&mut x| x % 2 == 0);
     assert_eq!(av.len(), 0);
   }
@@ -82,12 +82,13 @@ mod test {
 
     use core::fmt::Write;
     use alloc::string::String;
+    use hybrid_array::{Array, sizes::U2};
 
-    let mut ar: ConstGenericArray<S, 2> = ConstGenericArray::<S, 2>::from_array([S { x: 1, y: 2 }, S { x: 3, y: 4 }]);
+    let mut ar: Array<S, U2> = Array::<S, U2>([S { x: 1, y: 2 }, S { x: 3, y: 4 }]);
     let mut buf_ar = String::new();
     write!(&mut buf_ar, "{ar:#?}");
 
-    let av: TinyGenericVec<S, 2> = TinyGenericVec::<S, 2>::from_array_len(ar, 2);
+    let av: TinyHybridVec<S, 2> = TinyHybridVec::<S, 2>::from(ar);
     let mut buf_av = String::new();
     write!(&mut buf_av, "{av:#?}");
 

--- a/src/array/hybrid_array_impl.rs
+++ b/src/array/hybrid_array_impl.rs
@@ -86,12 +86,11 @@ mod test {
 
     let mut ar: Array<S, U2> = Array::<S, U2>([S { x: 1, y: 2 }, S { x: 3, y: 4 }]);
     let mut buf_ar = String::new();
-    write!(&mut buf_ar, "{ar:#?}");
+    write!(&mut buf_ar, "{:#?}", ar.as_slice()).unwrap();
 
     let av: TinyHybridVec<S, 2> = TinyHybridVec::<S, 2>::from(ar);
     let mut buf_av = String::new();
-    write!(&mut buf_av, "{av:#?}");
-
+    write!(&mut buf_av, "{av:#?}").unwrap();
     assert_eq!(buf_av, buf_ar)
   }
 }


### PR DESCRIPTION
Related PR: https://github.com/Lokathor/tinyvec/pull/204

I'm migrating a `no_std` project from [generic-array](https://docs.rs/generic-array/1.4.1/generic_array/) to [hybrid-array](https://docs.rs/hybrid-array/0.4.12/hybrid_array/index.html), and to get [tinyvec::ArrayVec](https://docs.rs/tinyvec/1.11.0/tinyvec/struct.ArrayVec.html) working again I must implement [tinyvec::Array](https://docs.rs/tinyvec/1.11.0/tinyvec/trait.Array.html) for [hybrid_array::Array](https://docs.rs/hybrid-array/0.4.12/hybrid_array/struct.Array.html) struct, which uses [ArraySize](https://docs.rs/hybrid-array/0.4.12/hybrid_array/trait.ArraySize.html) for define the array length.

So this PR does:
- [x] Adds [hybrid-array 0.4](https://docs.rs/hybrid-array/0.4.12/hybrid_array/) as an optional dependency.
- [x] Bump `generic-array 1.1.1` to `1.4.1`.
- [x]  implements the trait [tinyvec::Array](https://docs.rs/tinyvec/1.11.0/tinyvec/trait.Array.html) for [hybrid_array::Array](https://docs.rs/hybrid-array/0.4.12/hybrid_array/struct.Array.html) struct. when `hybrid-array` is enabled.
- [x] implements the trait [generic_array::IntoArrayLength](https://docs.rs/generic-array/latest/generic_array/trait.IntoArrayLength.html) for [tinyvec::ArrayVec](https://docs.rs/tinyvec/1.11.0/tinyvec/struct.ArrayVec.html) when `generic-array` is enabled.
- [x] implements the trait [hybrid_array::AssocArraySize](https://docs.rs/hybrid-array/0.4.12/hybrid_array/trait.AssocArraySize.html) for [tinyvec::ArrayVec](https://docs.rs/tinyvec/1.11.0/tinyvec/struct.ArrayVec.html) when `hybrid-array` is enabled.
- [x] Enable `hybrid-array/arbitray` and `generic-array/arbitrary` when `arbitrary` is enabled.
- [x] Enable `hybrid-array/serde` and `generic-array/serde` when `serde` is enabled.