### PR TITLE
Fix no std with alloc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,10 @@ jobs:
       if: matrix.rust == '1.60.0'
       run: |
         cargo check --features=alloc,std,grab_spare_slice
+    - name: Check no_std with alloc
+      if: matrix.rust != '1.60.0'
+      run: |
+        cargo check --no-default-features --features=alloc,grab_spare_slice,latest_stable_rust
     - name: Test non nightly
       if: matrix.rust != '1.60.0' && matrix.rust != 'nightly'
       run: |

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -707,7 +707,7 @@ impl<A: Array> TinyVec<A> {
     if len <= A::CAPACITY {
       TinyVec::Inline(ArrayVec::from_array_len(A::default(), len))
     } else {
-      TinyVec::Heap(vec![A::Item::default(); len])
+      TinyVec::Heap(alloc::vec![A::Item::default(); len])
     }
   }
 


### PR DESCRIPTION
Resolves https://github.com/Lokathor/tinyvec/issues/225.

It looks like the functionality added in https://github.com/Lokathor/tinyvec/pull/224 accidentally calls the bare vec! macro. 

This was not caught in tests, because no test configuration ran with alloc but without std.

This just changes it to match invocations elsewhere, plus adds test coverage.