### PR TITLE
fix: vec! macro resolution via alloc::vec self-import

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Check no_std with alloc
       if: matrix.rust != '1.60.0'
       run: |
-        cargo check --no-default-features --features=alloc,grab_spare_slice,latest_stable_rust
+        cargo check --tests --no-default-features --features=alloc,grab_spare_slice,latest_stable_rust
     - name: Test non nightly
       if: matrix.rust != '1.60.0' && matrix.rust != 'nightly'
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,10 @@ debugger_test_parser = "0.1"
 name = "tinyvec"
 required-features = ["alloc", "std"]
 
+[[test]]
+name = "no_std_macro"
+required-features = ["alloc"]
+
 [[bench]]
 name = "macros"
 harness = false

--- a/src/tinyvec.rs
+++ b/src/tinyvec.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use alloc::vec::{self, Vec};
+use alloc::vec::{Drain, Vec};
 use core::convert::TryFrom;
 use tinyvec_macros::impl_mirrored;
 
@@ -46,7 +46,7 @@ macro_rules! tiny_vec {
           f($crate::array_vec!($array_type => $($elem),*))
         }
         $crate::TinyVecConstructor::Heap(f) => {
-          f(vec![$($elem),*])
+          f($crate::alloc::vec![$($elem),*])
         }
       }
     }
@@ -1308,7 +1308,7 @@ pub enum TinyVecDrain<'p, A: Array> {
   #[allow(missing_docs)]
   Inline(ArrayVecDrain<'p, A::Item>),
   #[allow(missing_docs)]
-  Heap(vec::Drain<'p, A::Item>),
+  Heap(Drain<'p, A::Item>),
 }
 
 impl<'p, A: Array> Iterator for TinyVecDrain<'p, A> {

--- a/tests/no_std_macro.rs
+++ b/tests/no_std_macro.rs
@@ -1,0 +1,11 @@
+//! Regression test for the `tiny_vec!` macro's heap arm expanding cleanly
+//! in a downstream `#![no_std]` crate, where there is no `std` prelude
+//! `vec!` to mask a macro-hygiene resolution bug.
+#![no_std]
+
+use tinyvec::{tiny_vec, TinyVec};
+
+#[allow(dead_code)]
+fn expands_to_heap() -> TinyVec<[u8; 1]> {
+  tiny_vec!([u8; 1] => 1, 2)
+}


### PR DESCRIPTION
## Problem

`use alloc::vec::{self, Vec};` at the top of `src/tinyvec.rs` relies on the
`self` import also bringing the `vec!` macro into scope alongside the `vec`
module. On some toolchains that import only resolves the module (type
namespace), not the macro, so the unqualified `vec![...]` calls in this file
fail to compile with:

```
error: cannot find macro `vec` in this scope
   --> src/tinyvec.rs:710:21
    |
710 |       TinyVec::Heap(vec![A::Item::default(); len])
    |                     ^^^
    |
note: `vec` is imported here, but it is a module, not a macro
   --> src/tinyvec.rs:3:18
    |
  3 | use alloc::vec::{self, Vec};
    |                  ^^^^
```

### Toolchains where this reproduces

Reproduced building `tinyvec` 1.13.0 (`--features alloc`) on all three rustc
versions available to me, so it isn't specific to one release:

| rustc | commit | date |
|---|---|---|
| 1.94.1 | `e408947bf` | 2026-03-25 |
| 1.95.0 | `59807616e` | 2026-04-14 |
| 1.98.1 (latest stable) | `48a229cea` | 2026-09-01 |

(`rustc --version --verbose` output for each attached below.)

```
rustc 1.94.1 (e408947bf 2026-03-25)
host: aarch64-apple-darwin
LLVM version: 21.1.8

rustc 1.95.0 (59807616e 2026-04-14)
host: aarch64-apple-darwin
LLVM version: 22.1.2

rustc 1.98.1 (48a229cea 2026-09-01)
host: aarch64-apple-darwin
LLVM version: 22.1.8
```

This surfaced downstream via `unicode-normalization` (pulled in transitively
through `lancedb` → `lance` → `lance-tokenizer`), which depends on
`tinyvec`'s `alloc` feature and hits this exact code path.

## Fix

- Import `Drain` by name instead of importing the `vec` module via `self`.
- Fully qualify the two `vec!` call sites (`alloc::vec!` and
  `$crate::alloc::vec!` inside the exported `tiny_vec!` macro) so macro
  resolution no longer depends on the `self`-import behavior.

Verified `cargo build --features alloc` succeeds with this change on all
three toolchains listed above.